### PR TITLE
Dec trip changes

### DIFF
--- a/focal_plane.py
+++ b/focal_plane.py
@@ -1,61 +1,59 @@
-#from astropy.table import Table
-import sewpy
+# from astropy.table import Table
 import argparse
-import re
 import os
-import pandas as pd
+import re
 import subprocess
-
-
-from matplotlib.patches import Ellipse
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
+import sewpy
+from matplotlib.patches import Ellipse
 
 font = {'size': 14}
 import matplotlib
-#from sklearn import cluster
+# from sklearn import cluster
 from sklearn.cluster import KMeans
 
 matplotlib.rc('font', **font)
 
 try:
     import cv2
+
     has_cv2 = True
 except:
     print("Can't import cv2!!")
     has_cv2 = False
 
 import sys
+
 if not sys.version_info.major == 3:
     print("You are running python 2...")
     input = raw_input
 
-
 # Original GR cam lens with 8mm focal length used
-#pix2mm = 0.48244
-#x_corners = np.array([1210,1220,1957,1945])
-#y_corners = np.array([1374, 635, 648, 1385])
-#center=np.array([np.mean(x_corners), np.mean(y_corners)])
+# pix2mm = 0.48244
+# x_corners = np.array([1210,1220,1957,1945])
+# y_corners = np.array([1374, 635, 648, 1385])
+# center=np.array([np.mean(x_corners), np.mean(y_corners)])
 # center at ~60 deg is 1583. , 1010.5
 
 
 # New GR cam lens with 16mm focal length used (2x zoom in)
-#pix2mm = 0.2449
+# pix2mm = 0.2449
 PIX2MM = 0.241
 
-
-#these new corners mark the central module
-#x_corners = np.array([1762,1761,1980,1982])
-#y_corners = np.array([1175,954,952,1174])
-#center=np.array([np.mean(x_corners), np.mean(y_corners)])
-#center=np.array([1871.25, 1063.75])
+# these new corners mark the central module
+# x_corners = np.array([1762,1761,1980,1982])
+# y_corners = np.array([1175,954,952,1174])
+# center=np.array([np.mean(x_corners), np.mean(y_corners)])
+# center=np.array([1871.25, 1063.75])
 # center at ~-5 deg is 1871.25, 1063.75
 
-#x_corners = np.array([1782,1781,2000,2002])
-#y_corners = np.array([1175,954,952,1174])
-#center=np.array([np.mean(x_corners), np.mean(y_corners)])
-#center=np.array([1891.25, 1063.75])
+# x_corners = np.array([1782,1781,2000,2002])
+# y_corners = np.array([1175,954,952,1174])
+# center=np.array([np.mean(x_corners), np.mean(y_corners)])
+# center=np.array([1891.25, 1063.75])
 # center at ~60 deg is 1891.25, 1063.75
 # center at ~75 deg is 1896.25, 1063.75
 
@@ -63,23 +61,20 @@ PATTERN_LABEL_X_MIN = 1500
 PATTERN_LABEL_X_MAX = 1900
 PATTERN_LABEL_Y_MIN = 1500
 PATTERN_LABEL_Y_MAX = 1850
-PATTERN_CENTER_FROM_LABEL_BOUNDS = np.array([(PATTERN_LABEL_X_MIN + PATTERN_LABEL_X_MAX) / 2., (PATTERN_LABEL_Y_MIN + PATTERN_LABEL_Y_MAX) / 2.])
+PATTERN_CENTER_FROM_LABEL_BOUNDS = np.array(
+    [(PATTERN_LABEL_X_MIN + PATTERN_LABEL_X_MAX) / 2., (PATTERN_LABEL_Y_MIN + PATTERN_LABEL_Y_MAX) / 2.])
 
 
 def get_central_mod_corners(center=np.array([1891.25, 1063.75]),
-                            cmod_xoffset = np.array([-109.25, -110.25, 108.75, 110.75]),
-                            cmod_yoffset = np.array([ 111.25, -109.75, -111.75,  110.25])):
+                            cmod_xoffset=np.array([-109.25, -110.25, 108.75, 110.75]),
+                            cmod_yoffset=np.array([111.25, -109.75, -111.75, 110.25])):
     x_corners = cmod_xoffset + center[0]
     y_corners = cmod_yoffset + center[1]
     return x_corners, y_corners
 
 
-def get_panel_position_in_pattern(panel_id,
-                                  center=np.array([1891.25, 1063.75]),
-                                  radius_mm=np.array([20, 40]),
-                                  pixel_scale=0.241,
-                                  phase_offset_rad=0,
-                                  ):
+def get_panel_position_in_pattern(panel_id, center=np.array([1891.25, 1063.75]), radius_mm=np.array([20, 40]),
+                                  pixel_scale=0.241, phase_offset_rad=0, ):
     # in case of rx motion, we add a reference phase offset
     panel_id = str(panel_id)
 
@@ -103,7 +98,7 @@ def get_panel_position_in_pattern(panel_id,
     elif not is_primary and not is_inner_ring:
         total_segment = 4.
     phase = (quadrant - 1) * 0.5 * np.pi + 0.5 * np.pi * (segment - 0.5) / total_segment
-    #Here we rotate by phase offset
+    # Here we rotate by phase offset
     phase = phase + phase_offset_rad
 
     if is_inner_ring:
@@ -118,31 +113,24 @@ def get_panel_position_in_pattern(panel_id,
     return cx, cy, radius_pix, phase
 
 
-def find_all_pattern_positions(all_panels = np.array([1221, 1222, 1223, 1224, 1225, 1226, 1227, 1228, 1321, 1322, 1323,
-       1324, 1325, 1326, 1327, 1328, 1421, 1422, 1423, 1424, 1425, 1426,
-       1427, 1428, 1121, 1122, 1123, 1124, 1125, 1126, 1127, 1128, 1211,
-       1212, 1213, 1214, 1311, 1312, 1313, 1314, 1411, 1412, 1413, 1414,
-       1111, 1112, 1113, 1114]),
-                               center=np.array([1891.25, 1063.75]),
-                               radius_mm = np.array([20, 40]),
-                               phase_offset_rad = 0, #clockwise is positive, about 0.2 per outer panel
-                               pixel_scale = 0.241,
-                               outfile="dummy_pattern_position.txt",
-                               num_vvv = np.array([ 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17,
-       18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,  1,  2,
-        3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16])
-                              ):
-    df_pattern = pd.DataFrame({'Panel':all_panels, '#': num_vvv})
+def find_all_pattern_positions(all_panels=np.array(
+    [1221, 1222, 1223, 1224, 1225, 1226, 1227, 1228, 1321, 1322, 1323, 1324, 1325, 1326, 1327, 1328, 1421, 1422, 1423,
+     1424, 1425, 1426, 1427, 1428, 1121, 1122, 1123, 1124, 1125, 1126, 1127, 1128, 1211, 1212, 1213, 1214, 1311, 1312,
+     1313, 1314, 1411, 1412, 1413, 1414, 1111, 1112, 1113, 1114]), center=np.array([1891.25, 1063.75]),
+                               radius_mm=np.array([20, 40]), phase_offset_rad=0,
+                               # clockwise is positive, about 0.2 per outer panel
+                               pixel_scale=0.241, outfile="dummy_pattern_position.txt", num_vvv=np.array(
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+             30, 31, 32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])):
+    df_pattern = pd.DataFrame({'Panel': all_panels, '#': num_vvv})
     df_pattern['Xpix'] = 0
     df_pattern['Ypix'] = 0
     df_pattern['Rpix'] = 0
     df_pattern['Phase'] = 0
     for i, row in df_pattern.iterrows():
-        x_, y_, r_pix_, phase_ = get_panel_position_in_pattern(row['Panel'],
-                                                               center=center,
-                                                               radius_mm = radius_mm,
+        x_, y_, r_pix_, phase_ = get_panel_position_in_pattern(row['Panel'], center=center, radius_mm=radius_mm,
                                                                phase_offset_rad=phase_offset_rad,
-                                                               pixel_scale = pixel_scale)
+                                                               pixel_scale=pixel_scale)
         df_pattern.loc[i, 'Xpix'] = x_
         df_pattern.loc[i, 'Ypix'] = y_
         df_pattern.loc[i, 'Rpix'] = r_pix_
@@ -155,8 +143,8 @@ def find_all_pattern_positions(all_panels = np.array([1221, 1222, 1223, 1224, 12
 
 def read_raw(f='./GAS_image.raw', cols=2592, rows=1944, outfile=None, show=False):
     fd = open(f, 'rb')
-    f = np.fromfile(fd, dtype=np.uint8,count=rows*cols)
-    im = f.reshape((rows, cols)) #notice row, column format
+    f = np.fromfile(fd, dtype=np.uint8, count=rows * cols)
+    im = f.reshape((rows, cols))  # notice row, column format
     fd.close()
     if outfile is not None:
         if has_cv2:
@@ -187,16 +175,11 @@ def raw2fits(f='./GAS_image.raw', cols=2592, rows=1944, outfile=None):
 def im2fits(im, outfile, overwrite=True):
     from astropy.io import fits
     fitf = fits.PrimaryHDU(data=im)
-    fitf.writeto(outfile, overwrite=overwrite)
-    # return im
+    fitf.writeto(outfile, overwrite=overwrite)  # return im
 
 
-def plot_sew_cat(dst_trans, sew_out_trans,
-                 brightestN=0,
-                 xlim=None, ylim=None, outfile=None, show=False, vmax=None,
-                 pattern_label_x_min=0, pattern_label_x_max = 0,
-                 pattern_label_y_min = 0, pattern_label_y_max = 0
-):
+def plot_sew_cat(dst_trans, sew_out_trans, brightestN=0, xlim=None, ylim=None, outfile=None, show=False, vmax=None,
+                 pattern_label_x_min=0, pattern_label_x_max=0, pattern_label_y_min=0, pattern_label_y_max=0):
     '''
     Plots image with imshow. On top, plots only sources in sew_out_trans DF within the pattern search region.
     '''
@@ -215,38 +198,29 @@ def plot_sew_cat(dst_trans, sew_out_trans,
             break
         # print(row)
 
-
         kr = row['KRON_RADIUS']
-        e = Ellipse(xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]),
-                    width=row['A_IMAGE']*kr,
-                    height=row['B_IMAGE']*kr,
-                    angle=row['THETA_IMAGE'],
-                    linewidth=1, fill=False, alpha=0.9)
+        e = Ellipse(xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]), width=row['A_IMAGE'] * kr,
+                    height=row['B_IMAGE'] * kr, angle=row['THETA_IMAGE'], linewidth=1, fill=False, alpha=0.9)
         e.set_clip_box(ax.bbox)
         e.set_alpha(0.8)
         e.set_color('r')
         ax.add_artist(e)
 
-        if pattern_label_x_max>0 and pattern_label_y_max>0 and \
-                row['X_IMAGE'] <= pattern_label_x_max and row['X_IMAGE'] >= pattern_label_x_min and \
-                row['Y_IMAGE'] >= pattern_label_y_min and row['Y_IMAGE'] <= pattern_label_y_max:
-
+        if pattern_label_x_max > 0 and pattern_label_y_max > 0 and row['X_IMAGE'] <= pattern_label_x_max and row[
+            'X_IMAGE'] >= pattern_label_x_min and row['Y_IMAGE'] >= pattern_label_y_min and row[
+            'Y_IMAGE'] <= pattern_label_y_max:
             center_pattern = np.array(
                 [(pattern_label_x_min + pattern_label_x_max) / 2., (pattern_label_y_min + pattern_label_y_max) / 2.])
 
-            ax.annotate(int(row['ID']), xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]), size=8, xycoords='data',
-                        xytext=(np.array([row['X_IMAGE'] + row['X_IMAGE'] - center_pattern[0],
-                                          row['Y_IMAGE'] + row['Y_IMAGE'] - center_pattern[1]])),  # for orig lens
+            ax.annotate(int(row['ID']), xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]), size=8, xycoords='data', xytext=(
+                np.array([row['X_IMAGE'] + row['X_IMAGE'] - center_pattern[0],
+                          row['Y_IMAGE'] + row['Y_IMAGE'] - center_pattern[1]])),  # for orig lens
                         # xytext=(np.array([row['X_IMAGE'] - 80, row['Y_IMAGE'] - 80])),  # for new lens
                         color='c', alpha=0.8,
                         arrowprops=dict(facecolor='c', edgecolor='c', shrink=0.05, headwidth=1, headlength=4, width=0.5,
-                                        alpha=0.7),
-                        )
-            e = Ellipse(xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]),
-                        width=row['A_IMAGE'] * kr,
-                        height=row['B_IMAGE'] * kr,
-                        angle=row['THETA_IMAGE'],
-                        linewidth=1, fill=False, alpha=0.9)
+                                        alpha=0.7), )
+            e = Ellipse(xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]), width=row['A_IMAGE'] * kr,
+                        height=row['B_IMAGE'] * kr, angle=row['THETA_IMAGE'], linewidth=1, fill=False, alpha=0.9)
             ax.add_artist(e)
             e.set_color('c')
 
@@ -274,19 +248,20 @@ def calc_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS,
     With this cut, get averaged center of sources, mean and std of radius, and sliced sewtable.
     '''
 
-    if rad_frac>1 or rad_frac<0 or radius<0:
+    if rad_frac > 1 or rad_frac < 0 or radius < 0:
         print("Params to find ring pattern is not sensible")
         return
 
     if not fix_center:
         # figure out center here
-        xlo = (pattern_center[0] - (1+rad_frac)*radius )
-        xhi = (pattern_center[0] + (1+rad_frac)*radius )
-        ylo = (pattern_center[1] - (1+rad_frac)*radius )
-        yhi = (pattern_center[1] + (1+rad_frac)*radius )
+        xlo = (pattern_center[0] - (1 + rad_frac) * radius)
+        xhi = (pattern_center[0] + (1 + rad_frac) * radius)
+        ylo = (pattern_center[1] - (1 + rad_frac) * radius)
+        yhi = (pattern_center[1] + (1 + rad_frac) * radius)
 
-        sew_slice = sewtable[ (sewtable['X_IMAGE'] <=  xhi) & (sewtable['X_IMAGE'] >=  xlo) & \
-                              (sewtable['Y_IMAGE'] <=  yhi) & (sewtable['Y_IMAGE'] >=  ylo)  ]
+        sew_slice = sewtable[
+            (sewtable['X_IMAGE'] <= xhi) & (sewtable['X_IMAGE'] >= xlo) & (sewtable['Y_IMAGE'] <= yhi) & (
+                        sewtable['Y_IMAGE'] >= ylo)]
 
         if weight:
             centroidx = np.average(sew_slice['X_IMAGE'], weights=sew_slice['FLUX_ISO'])
@@ -300,12 +275,13 @@ def calc_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS,
         centroidy = pattern_center[1]
         sew_slice = sewtable
 
-    r2s = (sew_slice['X_IMAGE']-centroidx)**2+(sew_slice['Y_IMAGE']-centroidy)**2
+    r2s = (sew_slice['X_IMAGE'] - centroidx) ** 2 + (sew_slice['Y_IMAGE'] - centroidy) ** 2
 
     # iterate
     sew_slice['R_pattern'] = np.sqrt(r2s)
     # print(sew_slice)
-    sew_slice = sew_slice[(sew_slice['R_pattern'] <= (radius*(1+rad_frac))) & (sew_slice['R_pattern'] >= (radius*(1-rad_frac)))]
+    sew_slice = sew_slice[
+        (sew_slice['R_pattern'] <= (radius * (1 + rad_frac))) & (sew_slice['R_pattern'] >= (radius * (1 - rad_frac)))]
     # print("after")
     # print(sew_slice)
 
@@ -316,7 +292,7 @@ def calc_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS,
         centroidx = np.average(sew_slice['X_IMAGE'])
         centroidy = np.average(sew_slice['Y_IMAGE'])
 
-    r2s = (sew_slice['X_IMAGE']-centroidx)**2+(sew_slice['Y_IMAGE']-centroidy)**2
+    r2s = (sew_slice['X_IMAGE'] - centroidx) ** 2 + (sew_slice['Y_IMAGE'] - centroidy) ** 2
     phase = np.arcsin((centroidx - sew_slice['X_IMAGE']) / sew_slice['R_pattern'])
     sew_slice['Phase'] = phase
 
@@ -332,20 +308,20 @@ def calc_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS,
     return r2mean, r2std, new_center, new_radius, sew_slice
 
 
-def calc_ring_pattern_band(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS, radius=20 / PIX2MM, rad_inner=0.5, rad_outer=1.2,
-                           weight=False):
+def calc_ring_pattern_band(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS, radius=20 / PIX2MM, rad_inner=0.5,
+                           rad_outer=1.2, weight=False):
     # this is just a stupid calc func, no optimization / minimization
-    if radius<0 or rad_inner > 1 or rad_outer<1:
+    if radius < 0 or rad_inner > 1 or rad_outer < 1:
         print("Params to find ring pattern is not sensible")
         return
-    xlo = (pattern_center[0] - (rad_outer)*radius )
-    xhi = (pattern_center[0] + (rad_outer)*radius )
-    ylo = (pattern_center[1] - (rad_outer)*radius )
-    yhi = (pattern_center[1] + (rad_outer)*radius )
+    xlo = (pattern_center[0] - (rad_outer) * radius)
+    xhi = (pattern_center[0] + (rad_outer) * radius)
+    ylo = (pattern_center[1] - (rad_outer) * radius)
+    yhi = (pattern_center[1] + (rad_outer) * radius)
 
     # pass 1 just cut a square
-    sew_slice = sewtable[ (sewtable['X_IMAGE'] <=  xhi) & (sewtable['X_IMAGE'] >=  xlo) & \
-                          (sewtable['Y_IMAGE'] <=  yhi) & (sewtable['Y_IMAGE'] >=  ylo)  ]
+    sew_slice = sewtable[(sewtable['X_IMAGE'] <= xhi) & (sewtable['X_IMAGE'] >= xlo) & (sewtable['Y_IMAGE'] <= yhi) & (
+                sewtable['Y_IMAGE'] >= ylo)]
 
     if weight:
         centroidx = np.average(sew_slice['X_IMAGE'], weights=sew_slice['FLUX_ISO'])
@@ -354,15 +330,16 @@ def calc_ring_pattern_band(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BO
         centroidx = np.average(sew_slice['X_IMAGE'])
         centroidy = np.average(sew_slice['Y_IMAGE'])
 
-    r2s =  (sew_slice['X_IMAGE']-centroidx)**2+(sew_slice['Y_IMAGE']-centroidy)**2
+    r2s = (sew_slice['X_IMAGE'] - centroidx) ** 2 + (sew_slice['Y_IMAGE'] - centroidy) ** 2
 
-    #iterate; pass 2 cut annulus
+    # iterate; pass 2 cut annulus
     sew_slice['R_pattern'] = np.sqrt(r2s)
-    #print(sew_slice)
+    # print(sew_slice)
     # slice changed
-    sew_slice = sew_slice[(sew_slice['R_pattern'] <= (radius*(rad_inner))) & (sew_slice['R_pattern'] >= (radius*(rad_outer)))]
-    #print("after")
-    #print(sew_slice)
+    sew_slice = sew_slice[
+        (sew_slice['R_pattern'] <= (radius * (rad_inner))) & (sew_slice['R_pattern'] >= (radius * (rad_outer)))]
+    # print("after")
+    # print(sew_slice)
 
     # centroid changed
     if weight:
@@ -373,10 +350,11 @@ def calc_ring_pattern_band(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BO
         centroidy = np.average(sew_slice['Y_IMAGE'])
 
     # Rs changed; pass 3
-    r2s =  (sew_slice['X_IMAGE']-centroidx)**2+(sew_slice['Y_IMAGE']-centroidy)**2
+    r2s = (sew_slice['X_IMAGE'] - centroidx) ** 2 + (sew_slice['Y_IMAGE'] - centroidy) ** 2
     sew_slice['R_pattern'] = np.sqrt(r2s)
     # slice changed again
-    sew_slice = sew_slice[(sew_slice['R_pattern'] <= (radius*(rad_inner))) & (sew_slice['R_pattern'] >= (radius*(rad_outer)))]
+    sew_slice = sew_slice[
+        (sew_slice['R_pattern'] <= (radius * (rad_inner))) & (sew_slice['R_pattern'] >= (radius * (rad_outer)))]
 
     # centroid changed again
     if weight:
@@ -387,21 +365,19 @@ def calc_ring_pattern_band(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BO
         centroidy = np.average(sew_slice['Y_IMAGE'])
 
     r2mean = np.mean(r2s)
-    r2std = np.std(r2s)/(len(r2s)*1.0)
-    print("r2std={}, r2std/sqrt(N)={}".format(r2std, r2std*(len(r2s)*1.0)))
+    r2std = np.std(r2s) / (len(r2s) * 1.0)
+    print("r2std={}, r2std/sqrt(N)={}".format(r2std, r2std * (len(r2s) * 1.0)))
     newc = np.array([centroidx, centroidy])
     newr = np.sqrt(r2mean)
 
-    return r2mean, r2std, newc, newr, sew_slice # note that returned sew_slice may be of limited use
+    return r2mean, r2std, newc, newr, sew_slice  # note that returned sew_slice may be of limited use
 
 
-
-def radii_clustering(sewtable, n_rings=2,
-                     pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS, radius=20 / PIX2MM, rad_inner=0.5, rad_outer=1.2,
-                     weight=False):
+def radii_clustering(sewtable, n_rings=2, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS, radius=20 / PIX2MM,
+                     rad_inner=0.5, rad_outer=1.2, weight=False):
     # implementing
     # filtering
-    if radius<0 or rad_inner > 1 or rad_outer<1:
+    if radius < 0 or rad_inner > 1 or rad_outer < 1:
         print("Params to find ring pattern is not sensible")
         return
 
@@ -411,12 +387,13 @@ def radii_clustering(sewtable, n_rings=2,
     centroidy = pattern_center[1]
     sew_slice = sewtable
 
-    r2s =  (sew_slice['X_IMAGE']-centroidx)**2+(sew_slice['Y_IMAGE']-centroidy)**2
+    r2s = (sew_slice['X_IMAGE'] - centroidx) ** 2 + (sew_slice['Y_IMAGE'] - centroidy) ** 2
     sew_slice['R_pattern'] = np.sqrt(r2s)
-    sew_slice = sew_slice[(sew_slice['R_pattern'] <= (radius*(rad_inner))) & (sew_slice['R_pattern'] >= (radius*(rad_outer)))]
+    sew_slice = sew_slice[
+        (sew_slice['R_pattern'] <= (radius * (rad_inner))) & (sew_slice['R_pattern'] >= (radius * (rad_outer)))]
 
     kmeans_ = KMeans(n_clusters=n_rings)
-    clusters_ = kmeans_.fit_predict(sew_slice['R_pattern']) # clustering of radii^2
+    clusters_ = kmeans_.fit_predict(sew_slice['R_pattern'])  # clustering of radii^2
 
     sew_slice['Ring_ID'] = clusters_
 
@@ -432,13 +409,10 @@ def radii_clustering(sewtable, n_rings=2,
     return sew_slice, rad_means, rad_stds
 
 
-
 def find_ring_pattern_clustering(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS, radius=20 / PIX2MM,
-                                 rad_frac=0.2, rad_tol_frac=0.1,
-                                 n_rings=2, rad_inner=0.5, rad_outer=1.2,
-                                 rad_edges_pix=[50, 110, 150, 200], phase_offset = 0,
-                                 n_iter=50, chooseinner=False, chooseouter=False, tryouter=True,
-                                 ring_tol_rms=400):
+                                 rad_frac=0.2, rad_tol_frac=0.1, n_rings=2, rad_inner=0.5, rad_outer=1.2,
+                                 rad_edges_pix=[50, 110, 150, 200], phase_offset=0, n_iter=50, chooseinner=False,
+                                 chooseouter=False, tryouter=True, ring_tol_rms=400):
     # implementing
     """
     thoughts: we need to find imperfect rings, up to 3 rings, 1) 16 centroids from P1-S1 (bright); 2) 32 from P2-S1 (should be dimmer); 32 from P2-S2
@@ -452,19 +426,18 @@ def find_ring_pattern_clustering(sewtable, pattern_center=PATTERN_CENTER_FROM_LA
         (1221 / 1211 has reference phase of 0.53pi in picture)
 
     """
-    if rad_frac>1 or rad_frac<0 or radius<0 or n_rings>3 or n_rings<0:
+    if rad_frac > 1 or rad_frac < 0 or radius < 0 or n_rings > 3 or n_rings < 0:
         print("Params to find ring pattern is not sensible")
         return
 
     print("Doing clustering")
     good_ring = False
 
-    sew_slice, rad_means, rad_stds = radii_clustering(sewtable, n_rings=n_rings,
-                     pattern_center=pattern_center, radius=radius, rad_inner=rad_inner, rad_outer=rad_outer,
-                     )
+    sew_slice, rad_means, rad_stds = radii_clustering(sewtable, n_rings=n_rings, pattern_center=pattern_center,
+                                                      radius=radius, rad_inner=rad_inner, rad_outer=rad_outer, )
     print("R Variance not decreasing anymore on the {}th iteration.".format(i))
-    print("Rvar/N = {}".format(r2std_last/len(sew_slice)))
-    if rad_stds/len(sew_slice) < 400 and len(sew_slice)>4:
+    print("Rvar/N = {}".format(r2std_last / len(sew_slice)))
+    if rad_stds / len(sew_slice) < 400 and len(sew_slice) > 4:
         print("This seems to be a pretty good ring")
         good_ring = True
     else:
@@ -474,25 +447,24 @@ def find_ring_pattern_clustering(sewtable, pattern_center=PATTERN_CENTER_FROM_LA
 
     return
     if good_ring:
-        if abs(len(sew_slice)-16) <= abs(len(sew_slice)-32) or chooseinner:
-            #guess this is inner ring
+        if abs(len(sew_slice) - 16) <= abs(len(sew_slice) - 32) or chooseinner:
+            # guess this is inner ring
             df_pattern = find_all_pattern_positions(center=clast,
-                               radius_mm = np.array([rlast*0.241, rlast*2*0.241]),
-                               pixel_scale = 0.241,
-                               outfile=None,)
+                                                    radius_mm=np.array([rlast * 0.241, rlast * 2 * 0.241]),
+                                                    pixel_scale=0.241, outfile=None, )
             print("Found {} candidate centroid forming an inner ring".format(len(sew_slice)))
             print("Center {}, radius {}".format(clast, rlast))
-            df_slice = df_pattern[(abs(df_pattern.Rpix - rlast)<(rlast*rad_tol_frac))]
-            print("After applying a tolerance fraction cut = {}, {} panels left ".format(rad_tol_frac, df_slice.shape[0]))
+            df_slice = df_pattern[(abs(df_pattern.Rpix - rlast) < (rlast * rad_tol_frac))]
+            print(
+                "After applying a tolerance fraction cut = {}, {} panels left ".format(rad_tol_frac, df_slice.shape[0]))
             if tryouter:
-                df_outer_slice = df_pattern[(abs(df_pattern.Rpix - 2*rlast)<(2*rlast*rad_tol_frac))]
+                df_outer_slice = df_pattern[(abs(df_pattern.Rpix - 2 * rlast) < (2 * rlast * rad_tol_frac))]
                 df_slice.append(df_outer_slice)
-        elif abs(len(sew_slice)-16) > abs(len(sew_slice)-32) or chooseouter:
+        elif abs(len(sew_slice) - 16) > abs(len(sew_slice) - 32) or chooseouter:
             # not tested
             df_pattern = find_all_pattern_positions(center=clast,
-                                                    radius_mm=np.array([rlast/2 * 0.241, rlast * 0.241]),
-                                                    pixel_scale=0.241,
-                                                    outfile=None, )
+                                                    radius_mm=np.array([rlast / 2 * 0.241, rlast * 0.241]),
+                                                    pixel_scale=0.241, outfile=None, )
             df_slice = df_pattern[(abs(df_pattern.Rpix - rlast) < (rlast * rad_tol_frac))]
     else:
         df_slice = None
@@ -500,10 +472,9 @@ def find_ring_pattern_clustering(sewtable, pattern_center=PATTERN_CENTER_FROM_LA
     return clast, rlast, r2std_last, sew_slice, df_slice
 
 
-def find_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS, radius=20 / PIX2MM, rad_frac=0.2, rad_tol_frac=0.1,
-                      n_iter=50, chooseinner=False, chooseouter=False, tryouter=True, fix_center=True,
-                      phase_offset_rad = 0, get_center = False,
-                      var_tol=400):
+def find_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS, radius=20 / PIX2MM, rad_frac=0.2,
+                      rad_tol_frac=0.1, n_iter=50, chooseinner=False, chooseouter=False, tryouter=True, fix_center=True,
+                      phase_offset_rad=0, get_center=False, var_tol=400):
     '''
     Use sewtable of sources to find the mean centroid of the sources. Start with some radius and get the sources within that
     radius, their mean/std of their distances to center, and their mean center. Iterate with new radius cuts and new
@@ -511,7 +482,7 @@ def find_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS,
     Panel_ID label to each source in the corresponding locations.
 
     '''
-    if rad_frac>1 or rad_frac<0 or radius<0:
+    if rad_frac > 1 or rad_frac < 0 or radius < 0:
         print("Params to find ring pattern is not sensible")
         return
     r2std_last = 1e9
@@ -520,70 +491,72 @@ def find_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS,
     good_ring = False
     df_slice = None
 
-    centroidx = np.average(sewtable['X_IMAGE'])#, weights=sewtable['FLUX_ISO'])
-    centroidy = np.average(sewtable['Y_IMAGE'])#, weights=sewtable['FLUX_ISO'])
+    centroidx = np.average(sewtable['X_IMAGE'])  # , weights=sewtable['FLUX_ISO'])
+    centroidy = np.average(sewtable['Y_IMAGE'])  # , weights=sewtable['FLUX_ISO'])
 
-    if np.sqrt((centroidx - pattern_center[0])**2 + (centroidy - pattern_center[1])**2 ) > 100:
+    if np.sqrt((centroidx - pattern_center[0]) ** 2 + (centroidy - pattern_center[1]) ** 2) > 100:
         print("Your center is >100 pixels away from the flux-weighted center of gravity of all centroids")
         print("Flux-weighted center of gravity of all centroids is X={}, Y={}".format(centroidx, centroidy))
 
     for i in range(n_iter):
         r2mean, r2std, new_center, new_radius, sew_slice = calc_ring_pattern(sewtable, pattern_center=last_center,
-                                                      radius=last_radius, rad_frac=rad_frac, fix_center=fix_center)
+                                                                             radius=last_radius, rad_frac=rad_frac,
+                                                                             fix_center=fix_center)
         if r2std < r2std_last:
             last_center = new_center
             last_radius = new_radius
             r2std_last = r2std
         else:
             print("R Variance not decreasing anymore on the {}th iteration.".format(i))
-            print("Rvar/N = {}".format(r2std_last/len(sew_slice)))
+            print("Rvar/N = {}".format(r2std_last / len(sew_slice)))
             print("R = {} pix, center(x,y) = {}, {}".format(last_radius, last_center[0], last_center[1]))
-            if r2std_last/len(sew_slice) < var_tol and len(sew_slice)>4 and not get_center:
+            if r2std_last / len(sew_slice) < var_tol and len(sew_slice) > 4 and not get_center:
                 print("Found {} panels on this ring".format(len(sew_slice)))
                 print("This seems to be a pretty good ring")
                 good_ring = True
-            elif r2std_last/len(sew_slice) < var_tol:
+            elif r2std_last / len(sew_slice) < var_tol:
                 print("Found {} panels on this ring".format(len(sew_slice)))
                 print("This seems to be a pretty good ring")
                 good_ring = True
             else:
-                print("Crappy ring")
-            #break
+                print("Crappy ring")  # break
 
     if good_ring:
-        if abs(len(sew_slice)-16) + 4 <= abs(len(sew_slice)-32) or chooseinner:
-            #guess this is inner ring
+        if abs(len(sew_slice) - 16) + 4 <= abs(len(sew_slice) - 32) or chooseinner:
+            # guess this is inner ring
             df_pattern = find_all_pattern_positions(center=last_center,
-                               radius_mm = np.array([last_radius*0.241, last_radius*2*0.241]),
-                               pixel_scale = 0.241, phase_offset_rad=phase_offset_rad,
-                               outfile=None,)
+                                                    radius_mm=np.array([last_radius * 0.241, last_radius * 2 * 0.241]),
+                                                    pixel_scale=0.241, phase_offset_rad=phase_offset_rad,
+                                                    outfile=None, )
             print("Found {} candidate centroid forming an inner ring".format(len(sew_slice)))
             print("Center {}, radius {}".format(last_center, last_radius))
-            df_slice = df_pattern[(abs(df_pattern.Rpix - last_radius)<(last_radius*rad_tol_frac))]
-            print("After applying a tolerance fraction cut = {}, {} panels left ".format(rad_tol_frac, df_slice.shape[0]))
+            df_slice = df_pattern[(abs(df_pattern.Rpix - last_radius) < (last_radius * rad_tol_frac))]
+            print(
+                "After applying a tolerance fraction cut = {}, {} panels left ".format(rad_tol_frac, df_slice.shape[0]))
             if tryouter:
-                df_outer_slice = df_pattern[(abs(df_pattern.Rpix - 2*last_radius)<(2*last_radius*rad_tol_frac))]
+                df_outer_slice = df_pattern[(abs(df_pattern.Rpix - 2 * last_radius) < (2 * last_radius * rad_tol_frac))]
                 df_slice.append(df_outer_slice)
-        elif abs(len(sew_slice)-16) > abs(len(sew_slice)-32) or chooseouter:
+        elif abs(len(sew_slice) - 16) > abs(len(sew_slice) - 32) or chooseouter:
             # not tested
             df_pattern = find_all_pattern_positions(center=last_center,
-                                                    radius_mm=np.array([last_radius/2 * 0.241, last_radius * 0.241]),
+                                                    radius_mm=np.array([last_radius / 2 * 0.241, last_radius * 0.241]),
                                                     pixel_scale=0.241, phase_offset_rad=phase_offset_rad,
                                                     outfile=None, )
             print("Found {} candidate centroid forming an outer ring".format(len(sew_slice)))
             print("Center {}, radius {}".format(last_center, last_radius))
             df_slice = df_pattern[(abs(df_pattern.Rpix - last_radius) < (last_radius * rad_tol_frac))]
-            print("After applying a tolerance fraction cut = {}, {} panels left ".format(rad_tol_frac, df_slice.shape[0]))
+            print(
+                "After applying a tolerance fraction cut = {}, {} panels left ".format(rad_tol_frac, df_slice.shape[0]))
     else:
         df_slice = None
 
     return last_center, last_radius, r2std_last, sew_slice, df_slice
 
 
-def find_single_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS, radius=20 / PIX2MM, rad_frac=0.2, rad_tol_frac=0.1,
-                             n_iter=50, ):
-    #implementing, may dropt it
-    if rad_frac>1 or rad_frac<0 or radius<0:
+def find_single_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_BOUNDS, radius=20 / PIX2MM,
+                             rad_frac=0.2, rad_tol_frac=0.1, n_iter=50, ):
+    # implementing, may dropt it
+    if rad_frac > 1 or rad_frac < 0 or radius < 0:
         print("Params to find ring pattern is not sensible")
         return
     r2std_last = 1e9
@@ -591,16 +564,16 @@ def find_single_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_
     rlast = radius
     good_ring = False
     for i in range(n_iter):
-        r2mean, r2std, newc, newr, sew_slice = calc_ring_pattern(sewtable, pattern_center=clast,
-                                                      radius=rlast, rad_frac=rad_frac)
+        r2mean, r2std, newc, newr, sew_slice = calc_ring_pattern(sewtable, pattern_center=clast, radius=rlast,
+                                                                 rad_frac=rad_frac)
         if r2std < r2std_last:
             clast = newc
             rlast = newr
             r2std_last = r2std
         else:
             print("R Variance not decreasing anymore on the {}th iteration.".format(i))
-            print("Rvar/N = {}".format(r2std_last/len(sew_slice)))
-            if r2std_last/len(sew_slice) < 400 and len(sew_slice)>4:
+            print("Rvar/N = {}".format(r2std_last / len(sew_slice)))
+            if r2std_last / len(sew_slice) < 400 and len(sew_slice) > 4:
                 print("This seems to be a pretty good ring")
                 good_ring = True
             else:
@@ -608,35 +581,26 @@ def find_single_ring_pattern(sewtable, pattern_center=PATTERN_CENTER_FROM_LABEL_
             break
 
     if good_ring:
-            df_pattern = find_all_pattern_positions(center=clast,
-                               radius_mm = np.array([rlast*0.241, rlast*2*0.241]),
-                               pixel_scale = 0.241,
-                               outfile=None,)
-            print("Found {} candidate centroid forming an inner ring".format(len(sew_slice)))
-            print("Center {}, radius {}".format(clast, rlast))
-            df_slice = df_pattern[(abs(df_pattern.Rpix - rlast)<(rlast*rad_tol_frac))]
-            print("After applying a tolerance fraction cut = {}, {} panels left ".format(rad_tol_frac, df_slice.shape[0]))
-            if tryouter:
-                df_outer_slice = df_pattern[(abs(df_pattern.Rpix - 2*rlast)<(2*rlast*rad_tol_frac))]
-                df_slice.append(df_outer_slice)
+        df_pattern = find_all_pattern_positions(center=clast, radius_mm=np.array([rlast * 0.241, rlast * 2 * 0.241]),
+                                                pixel_scale=0.241, outfile=None, )
+        print("Found {} candidate centroid forming an inner ring".format(len(sew_slice)))
+        print("Center {}, radius {}".format(clast, rlast))
+        df_slice = df_pattern[(abs(df_pattern.Rpix - rlast) < (rlast * rad_tol_frac))]
+        print("After applying a tolerance fraction cut = {}, {} panels left ".format(rad_tol_frac, df_slice.shape[0]))
+        if tryouter:
+            df_outer_slice = df_pattern[(abs(df_pattern.Rpix - 2 * rlast) < (2 * rlast * rad_tol_frac))]
+            df_slice.append(df_outer_slice)
     else:
         df_slice = None
 
     return clast, rlast, r2std_last, sew_slice, df_slice
 
 
-
-
-def process_raw(rawfile, kernel_w = 3,
-                DETECT_MINAREA = 30, THRESH = 5,
-                DEBLEND_MINCONT=0.02,
-                clean=True,
-                sewpy_params=["X_IMAGE", "Y_IMAGE", "FLUX_ISO", "KRON_RADIUS", "FLUX_RADIUS", "FLAGS", "A_IMAGE", "B_IMAGE", "THETA_IMAGE"],
-                cropxs=(1350, 1800), cropys=(1250, 800),
-                savecatalog_name=None,
-                savefits_name=None, overwrite_fits=True,
-                saveplot_name=None, show=False,
-                search_xs=[0,0], search_ys=[0,0]):
+def process_raw(rawfile, kernel_w=3, DETECT_MINAREA=30, THRESH=5, DEBLEND_MINCONT=0.02, clean=True,
+                sewpy_params=["X_IMAGE", "Y_IMAGE", "FLUX_ISO", "KRON_RADIUS", "FLUX_RADIUS", "FLAGS", "A_IMAGE",
+                              "B_IMAGE", "THETA_IMAGE"], cropxs=(1350, 1800), cropys=(1250, 800), savecatalog_name=None,
+                savefits_name=None, overwrite_fits=True, saveplot_name=None, show=False, search_xs=[0, 0],
+                search_ys=[0, 0]):
     '''
     This actually processes the file with sewpy and extracts sources. The 'rawfile' is a matrix (not the path to the .RAW image).
     After processing with sewpy, it pushes the extracted sources object to a Pandas dataframe, then cleans for flags and search region.
@@ -658,7 +622,7 @@ def process_raw(rawfile, kernel_w = 3,
     max_pixel_crop = np.max(median[cropys[1]:cropys[0], cropxs[0]:cropxs[1]])
     print("Brightest pixel in the zoomed area reaches {}".format(max_pixel_crop))
     if savefits_name is None:
-        savefits_name = rawfile[:-4]+".fits"
+        savefits_name = rawfile[:-4] + ".fits"
     elif savefits_name[-4:] != ("fits" or "fit"):
         print("Please provide a filename with fits or fit extension")
         exit(0)
@@ -666,35 +630,31 @@ def process_raw(rawfile, kernel_w = 3,
     im2fits(median, savefits_name, overwrite=overwrite_fits)
 
     sew = sewpy.SEW(params=sewpy_params,
-                    config={"DETECT_MINAREA": DETECT_MINAREA,
-                            "BACK_SIZE":128 ,
-                            "BACK_FILTERSIZE":3,
-                            "DETECT_THRESH": THRESH, "ANALYSIS_THRESH": THRESH,
-                            "DEBLEND_MINCONT": DEBLEND_MINCONT,
-                            }
-                    )
+                    config={"DETECT_MINAREA": DETECT_MINAREA, "BACK_SIZE": 128, "BACK_FILTERSIZE": 3,
+                            "DETECT_THRESH": THRESH, "ANALYSIS_THRESH": THRESH, "DEBLEND_MINCONT": DEBLEND_MINCONT, })
 
     sew_out = sew(savefits_name)
     sew_out['table'].sort('FLUX_ISO')
     sew_out['table'].reverse()
-    sew_out['table']['FLUX_AREA'] = (1. /4.) *np.pi * sew_out['table']['KRON_RADIUS'] * sew_out['table']['KRON_RADIUS'] * \
-                                    sew_out['table']['A_IMAGE'] * sew_out['table']['B_IMAGE']
+    sew_out['table']['FLUX_AREA'] = (1. / 4.) * np.pi * sew_out['table']['KRON_RADIUS'] * sew_out['table'][
+        'KRON_RADIUS'] * sew_out['table']['A_IMAGE'] * sew_out['table']['B_IMAGE']
     if clean:
-        sew_out['table'] = sew_out['table'][sew_out['table']['FLAGS'] <= 16]
-        # sew_out['table'] = sew_out['table'][(sew_out['table']['FLUX_ISO'] / sew_out['table']['FLUX_AREA']) > 0.3]
+        sew_out['table'] = sew_out['table'][sew_out['table'][
+                                                'FLAGS'] <= 16]  # sew_out['table'] = sew_out['table'][(sew_out['table']['FLUX_ISO'] / sew_out['table']['FLUX_AREA']) > 0.3]
 
-    ymin=0
-    ymax=0
-    if search_xs[1]>0 and search_ys[1]>=0 and search_ys[0] != search_ys[1]:
+    ymin = 0
+    ymax = 0
+    if search_xs[1] > 0 and search_ys[1] >= 0 and search_ys[0] != search_ys[1]:
         if search_ys[1] < search_ys[0]:
-            ymin=search_ys[1]
-            ymax=search_ys[0]
+            ymin = search_ys[1]
+            ymax = search_ys[0]
         else:
-            ymin=search_ys[0]
-            ymax=search_ys[1]
+            ymin = search_ys[0]
+            ymax = search_ys[1]
         print("Only searching in X {} to {} and Y {} to {}".format(search_xs[0], search_xs[1], ymin, ymax))
-        sew_out['table'] = sew_out['table'][(sew_out['table']['X_IMAGE'] <= search_xs[1]) & (sew_out['table']['X_IMAGE'] >= search_xs[0]) & \
-                                            (sew_out['table']['Y_IMAGE'] <= ymax) &(sew_out['table']['Y_IMAGE'] >= ymin)]
+        sew_out['table'] = sew_out['table'][
+            (sew_out['table']['X_IMAGE'] <= search_xs[1]) & (sew_out['table']['X_IMAGE'] >= search_xs[0]) & (
+                        sew_out['table']['Y_IMAGE'] <= ymax) & (sew_out['table']['Y_IMAGE'] >= ymin)]
 
     n_sources = len(sew_out['table'])
     ID_ = Column(range(n_sources), name='ID')
@@ -703,12 +663,9 @@ def process_raw(rawfile, kernel_w = 3,
 
     print("Found {} sources in file {}".format(n_sources, rawfile))
 
-    plot_sew_cat(median, sew_out,
-                 outfile=saveplot_name,
-                 xlim=cropxs,
-                 ylim=cropys, vmax=max_pixel_crop,
-                 pattern_label_x_min=search_xs[0], pattern_label_x_max=search_xs[1],
-                 pattern_label_y_min=ymin, pattern_label_y_max=ymax)
+    plot_sew_cat(median, sew_out, outfile=saveplot_name, xlim=cropxs, ylim=cropys, vmax=max_pixel_crop,
+                 pattern_label_x_min=search_xs[0], pattern_label_x_max=search_xs[1], pattern_label_y_min=ymin,
+                 pattern_label_y_max=ymax)
     if savecatalog_name is not None:
         from astropy.io import ascii
         ascii.write(sew_out['table'], savecatalog_name, overwrite=True)
@@ -717,13 +674,9 @@ def process_raw(rawfile, kernel_w = 3,
     return sew_out['table'], median
 
 
-
-def plot_raw_cat(rawfile, sewtable, df=None, center_pattern=np.array([1891.25, 1063.75]),
-                 cropxs=(1050, 2592), cropys=(1850, 250),
-                 kernel_w = 3,
-                 save_catlog_name="temp_ring_search_cat.txt",
-                 save_for_vvv="temp_ring_vvv_XY_pix.csv",
-                 saveplot_name=None, show=False):
+def plot_raw_cat(rawfile, sewtable, df=None, center_pattern=np.array([1891.25, 1063.75]), cropxs=(1050, 2592),
+                 cropys=(1850, 250), kernel_w=3, save_catlog_name="temp_ring_search_cat.txt",
+                 save_for_vvv="temp_ring_vvv_XY_pix.csv", saveplot_name=None, show=False):
     '''
     Plots raw file (path to .RAW image) with imshow. If there is a 'df' object - this object is assumed to be the VVV
     list of panels in the ring - find minimum distance between that source with source in the sewtable and assign that
@@ -750,8 +703,8 @@ def plot_raw_cat(rawfile, sewtable, df=None, center_pattern=np.array([1891.25, 1
     fig, ax = plt.subplots(subplot_kw={'aspect': 'equal'})
 
     ax_img = ax.imshow(median, vmax=max_pixel_crop, cmap='gray')
-    #else:
-    #ax_img = ax.imshow(dst_trans, cmap='gray')
+    # else:
+    # ax_img = ax.imshow(dst_trans, cmap='gray')
     fig.colorbar(ax_img)
 
     # plt.plot(cat_test['X_IMAGE'], cat_test['Y_IMAGE'], color='r',  marker='o', ms=5, ls='')
@@ -763,11 +716,8 @@ def plot_raw_cat(rawfile, sewtable, df=None, center_pattern=np.array([1891.25, 1
     for row in sewtable:
         i += 1
         kr = row['KRON_RADIUS']
-        e = Ellipse(xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]),
-                    width=row['A_IMAGE']*kr,
-                    height=row['B_IMAGE']*kr,
-                    angle=row['THETA_IMAGE'],
-                    linewidth=1, fill=False, alpha=0.9)
+        e = Ellipse(xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]), width=row['A_IMAGE'] * kr,
+                    height=row['B_IMAGE'] * kr, angle=row['THETA_IMAGE'], linewidth=1, fill=False, alpha=0.9)
         e.set_clip_box(ax.bbox)
         e.set_alpha(0.8)
         e.set_color('c')
@@ -778,8 +728,8 @@ def plot_raw_cat(rawfile, sewtable, df=None, center_pattern=np.array([1891.25, 1
             pID = df.loc[df['tmpdist2'].idxmin(), 'Panel']
             vvvID = df.loc[df['tmpdist2'].idxmin(), '#']
             print("Guess this is panel {}".format(pID))
-            if i>1:
-                #if pID == sewtable['Panel_ID_guess'][i-1] or vvvID:
+            if i > 1:
+                # if pID == sewtable['Panel_ID_guess'][i-1] or vvvID:
                 if pID in sewtable['Panel_ID_guess']:
                     print("Panel {} already found...".format(pID))
                     print("Sorry I haven't figured out this part yet")
@@ -790,23 +740,20 @@ def plot_raw_cat(rawfile, sewtable, df=None, center_pattern=np.array([1891.25, 1
                     vvvID = df.loc[df['tmpistphase'].idxmin(), '#']
                     print("Now I guess this is panel {}".format(pID))
                     """
-            sewtable['Panel_ID_guess'][i-1] = pID
-            sewtable['#'][i-1] = vvvID
+            sewtable['Panel_ID_guess'][i - 1] = pID
+            sewtable['#'][i - 1] = vvvID
             plt.plot(df['Xpix'], df['Ypix'], 'm.', markersize=4, alpha=0.3)
         else:
             pID = int(row['ID'])
 
-
         ax.annotate(pID, xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]), size=8, xycoords='data',
-                # xytext=(np.array([row['X_IMAGE'] - 40, row['Y_IMAGE'] - 40])), # for orig lens
-                xytext=(np.array([row['X_IMAGE'] + row['X_IMAGE'] - center_pattern[0],
-                                  row['Y_IMAGE'] + row['Y_IMAGE'] - center_pattern[1]])),  # for orig lens
-                # xytext=(np.array([row['X_IMAGE'] - 80, row['Y_IMAGE'] - 80])),  # for new lens
-                color='c', alpha=0.8,
-                arrowprops=dict(facecolor='c', edgecolor='c', shrink=0.05, headwidth=1, headlength=4, width=0.5,
-                                alpha=0.7),
-                )
-
+                    # xytext=(np.array([row['X_IMAGE'] - 40, row['Y_IMAGE'] - 40])), # for orig lens
+                    xytext=(np.array([row['X_IMAGE'] + row['X_IMAGE'] - center_pattern[0],
+                                      row['Y_IMAGE'] + row['Y_IMAGE'] - center_pattern[1]])),  # for orig lens
+                    # xytext=(np.array([row['X_IMAGE'] - 80, row['Y_IMAGE'] - 80])),  # for new lens
+                    color='c', alpha=0.8,
+                    arrowprops=dict(facecolor='c', edgecolor='c', shrink=0.05, headwidth=1, headlength=4, width=0.5,
+                                    alpha=0.7), )
 
     if cropxs is not None:
         plt.xlim(cropxs)
@@ -826,22 +773,19 @@ def plot_raw_cat(rawfile, sewtable, df=None, center_pattern=np.array([1891.25, 1
     if df is not None:
         # no 'crappy' files for vvv (N.B 'crappy' is undefined and subject to change)
         df_vvv = df.to_pandas()
-        df_vvv['A_x_KR_in_pix'] = df_vvv["KRON_RADIUS"]*df_vvv['A_IMAGE'] / 2.
-        df_vvv['B_x_KR_in_pix'] = df_vvv["KRON_RADIUS"]*df_vvv['B_IMAGE'] / 2.
-        df_vvv = df_vvv[['Panel_ID_guess', '#', 'X_IMAGE', 'Y_IMAGE', "A_x_KR_in_pix", "B_x_KR_in_pix",
-                                                      "THETA_IMAGE",'FLUX_AREA','KRON_RADIUS']]
+        df_vvv['A_x_KR_in_pix'] = df_vvv["KRON_RADIUS"] * df_vvv['A_IMAGE'] / 2.
+        df_vvv['B_x_KR_in_pix'] = df_vvv["KRON_RADIUS"] * df_vvv['B_IMAGE'] / 2.
+        df_vvv = df_vvv[
+            ['Panel_ID_guess', '#', 'X_IMAGE', 'Y_IMAGE', "A_x_KR_in_pix", "B_x_KR_in_pix", "THETA_IMAGE", 'FLUX_AREA',
+             'KRON_RADIUS']]
         df_vvv.sort_values('#').to_csv(save_for_vvv, index=False)
         print("Mean center X {} Y {}".format(np.mean(df_vvv['X_IMAGE']), np.mean(df_vvv['Y_IMAGE'])))
 
     return
 
 
-def quick_check_raw_ring(rawfile,
-                         save_for_vvv="temp_ring_vvv_XY_pix.csv",
-                         saveplot_name=None, show=False,
-                         kernel_w = 3,
-                         cropxs=(1050, 2592), cropys=(1850, 250),):
-    from astropy.table import Column
+def quick_check_raw_ring(rawfile, save_for_vvv="temp_ring_vvv_XY_pix.csv", saveplot_name=None, show=False, kernel_w=3,
+                         cropxs=(1050, 2592), cropys=(1850, 250), ):
     im_raw = read_raw(rawfile)
     if has_cv2:
         median = cv2.medianBlur(im_raw, kernel_w)
@@ -857,9 +801,9 @@ def quick_check_raw_ring(rawfile,
     fig, ax = plt.subplots(subplot_kw={'aspect': 'equal'})
 
     ax_img = ax.imshow(median, vmax=max_pixel_crop, cmap='gray')
-    #else:
-    #ax_img = ax.imshow(dst_trans, cmap='gray')
-    #fig.colorbar(ax_img)
+    # else:
+    # ax_img = ax.imshow(dst_trans, cmap='gray')
+    # fig.colorbar(ax_img)
 
     # plt.plot(cat_test['X_IMAGE'], cat_test['Y_IMAGE'], color='r',  marker='o', ms=5, ls='')
     # plt.scatter(sew_out_trans['table']['X_IMAGE'],
@@ -870,14 +814,13 @@ def quick_check_raw_ring(rawfile,
 
     for i, row in df.iterrows():
         ax.annotate(int(row['Panel_ID_guess']), xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]), size=8, xycoords='data',
-                # xytext=(np.array([row['X_IMAGE'] - 40, row['Y_IMAGE'] - 40])), # for orig lens
-                xytext=(np.array([row['X_IMAGE'] + (row['X_IMAGE'] - center_pattern[0])*1.3,
-                                  row['Y_IMAGE'] + (row['Y_IMAGE'] - center_pattern[1])*1.3] )),  # for orig lens
-                # xytext=(np.array([row['X_IMAGE'] - 80, row['Y_IMAGE'] - 80])),  # for new lens
-                color='c', alpha=0.6,
-                arrowprops=dict(facecolor='c', edgecolor='c', shrink=0.05, headwidth=0.5, headlength=4, width=0.2,
-                                alpha=0.4),
-                )
+                    # xytext=(np.array([row['X_IMAGE'] - 40, row['Y_IMAGE'] - 40])), # for orig lens
+                    xytext=(np.array([row['X_IMAGE'] + (row['X_IMAGE'] - center_pattern[0]) * 1.3,
+                                      row['Y_IMAGE'] + (row['Y_IMAGE'] - center_pattern[1]) * 1.3])),  # for orig lens
+                    # xytext=(np.array([row['X_IMAGE'] - 80, row['Y_IMAGE'] - 80])),  # for new lens
+                    color='c', alpha=0.6,
+                    arrowprops=dict(facecolor='c', edgecolor='c', shrink=0.05, headwidth=0.5, headlength=4, width=0.2,
+                                    alpha=0.4), )
     if cropxs is not None:
         plt.xlim(cropxs)
     if cropys is not None:
@@ -890,17 +833,12 @@ def quick_check_raw_ring(rawfile,
         plt.show()
 
 
-def naive_comparison(sew_out_table1, sew_out_table2, im1, im2,
-                     min_dist=20,
-                     outfile1=None, outfile2=None, verbose=False,
-                     diffcat1="diff_cat1.txt", diffcat2="diff_cat2.txt",
-                     cropxs=(1050, 2592), cropys=(1410, 610),
-                     center=np.array([1891.25, 1063.75])
-                     ):
-
+def naive_comparison(sew_out_table1, sew_out_table2, im1, im2, min_dist=20, outfile1=None, outfile2=None, verbose=False,
+                     diffcat1="diff_cat1.txt", diffcat2="diff_cat2.txt", cropxs=(1050, 2592), cropys=(1410, 610),
+                     center=np.array([1891.25, 1063.75])):
     x_corners, y_corners = get_central_mod_corners(center=center)
 
-    #xy_common=[]
+    # xy_common=[]
     diff_ind1 = range(len(sew_out_table1))
     diff_ind2 = range(len(sew_out_table2))
     commond_ind1 = []
@@ -914,8 +852,8 @@ def naive_comparison(sew_out_table1, sew_out_table2, im1, im2,
         diffcat2_io.write("\n")
 
     max_pixel_crop2 = np.max(im2[cropys[1]:cropys[0], cropxs[0]:cropxs[1]])
-    #print("Brightest pixel in the zoomed area in image 2 reaches {}".format(max_pixel_crop2))
-    #if max_pixel_crop2 == 255:
+    # print("Brightest pixel in the zoomed area in image 2 reaches {}".format(max_pixel_crop2))
+    # if max_pixel_crop2 == 255:
     #    print("Image 2 is saturated. ")
 
     fig, ax = plt.subplots(subplot_kw={'aspect': 'equal'})
@@ -930,118 +868,107 @@ def naive_comparison(sew_out_table1, sew_out_table2, im1, im2,
         f2_ = row['FLUX_ISO']
         kr = row['KRON_RADIUS']
         xy2_ = np.array([x2_, y2_])
-        i2+=1
+        i2 += 1
         i1 = -1
         for row1 in sew_out_table1:
-            i1+=1
+            i1 += 1
             x1_ = row1['X_IMAGE']
             y1_ = row1['Y_IMAGE']
             f1_ = row1['FLUX_ISO']
             xy1_ = np.array([x1_, y1_])
-            dist_ = np.linalg.norm(xy1_-xy2_)
+            dist_ = np.linalg.norm(xy1_ - xy2_)
             if dist_ <= min_dist:
-                #xy_common.append((xy1_+xy2_)/2.)
+                # xy_common.append((xy1_+xy2_)/2.)
                 commond_ind1.append(i1)
                 commond_ind2.append(i2)
-                e = Ellipse(xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]),
-                            width=row['A_IMAGE']*kr,
-                            height=row['B_IMAGE']*kr,
-                            angle=row['THETA_IMAGE'],
-                            linewidth=1, fill=False, alpha=0.9)
+                e = Ellipse(xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]), width=row['A_IMAGE'] * kr,
+                            height=row['B_IMAGE'] * kr, angle=row['THETA_IMAGE'], linewidth=1, fill=False, alpha=0.9)
                 ax.add_artist(e)
                 e.set_clip_box(ax.bbox)
                 e.set_alpha(0.8)
                 e.set_color('r')
 
-                #if row['X_IMAGE'] <= 2100 and row['X_IMAGE'] >= 1700 and row['Y_IMAGE'] >= 880 and row[
+                # if row['X_IMAGE'] <= 2100 and row['X_IMAGE'] >= 1700 and row['Y_IMAGE'] >= 880 and row[
                 #    'Y_IMAGE'] <= 1250:
                 if row['X_IMAGE'] <= PATTERN_LABEL_X_MAX and row['X_IMAGE'] >= PATTERN_LABEL_X_MIN and row[
-                    'Y_IMAGE'] >= PATTERN_LABEL_Y_MIN and row[
-                    'Y_IMAGE'] <= PATTERN_LABEL_Y_MAX:
-                    #print("Yo")
-                    #print(int(row['ID']), row['X_IMAGE'], row['Y_IMAGE'])
+                    'Y_IMAGE'] >= PATTERN_LABEL_Y_MIN and row['Y_IMAGE'] <= PATTERN_LABEL_Y_MAX:
+                    # print("Yo")
+                    # print(int(row['ID']), row['X_IMAGE'], row['Y_IMAGE'])
                     ax.annotate(int(row['ID']), xy=np.array([row['X_IMAGE'], row['Y_IMAGE']]), size=8, xycoords='data',
                                 xytext=(np.array([row['X_IMAGE'] + row['X_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[0],
-                                                  row['Y_IMAGE'] + row['Y_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[1]])),  # for orig lens
-                                #xytext=(np.array([row['X_IMAGE'] - 80, row['Y_IMAGE'] - 80])),  # for new lens
+                                                  row['Y_IMAGE'] + row['Y_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[
+                                                      1]])),  # for orig lens
+                                # xytext=(np.array([row['X_IMAGE'] - 80, row['Y_IMAGE'] - 80])),  # for new lens
                                 color='c', alpha=0.8,
                                 arrowprops=dict(facecolor='c', edgecolor='c', shrink=0.05, headwidth=1, headlength=2,
-                                                width=0.5,
-                                                alpha=0.7),
-                                )
+                                                width=0.5, alpha=0.7), )
 
-                #e.set_facecolor('r')
+                # e.set_facecolor('r')
                 try:
                     diff_ind1.remove(i1)
                 except:
-                    #if verbose:
+                    # if verbose:
                     #    print("Double Match 1...... !!!!!")
                     #    print(diff_ind1)
-                    #else:
+                    # else:
                     pass
                 try:
                     diff_ind2.remove(i2)
                 except:
-                    #if verbose:
+                    # if verbose:
                     #    print("Double Match 2...... !!!!!")
                     #    print(diff_ind2)
-                    #else:
+                    # else:
                     pass
-
 
     i2 = -1
     for row1 in sew_out_table2:
-            i2+=1
-            if i2 not in diff_ind2:
-                continue
-            x1_ = row1['X_IMAGE']
-            y1_ = row1['Y_IMAGE']
-            f1_ = row1['FLUX_ISO']
-            kr1 = row1['KRON_RADIUS']
-            xy1_ = np.array([x1_, y1_])
-            if verbose:
-                print("==== New in catalog 2 ====")
-                print(xy1_)
+        i2 += 1
+        if i2 not in diff_ind2:
+            continue
+        x1_ = row1['X_IMAGE']
+        y1_ = row1['Y_IMAGE']
+        f1_ = row1['FLUX_ISO']
+        kr1 = row1['KRON_RADIUS']
+        xy1_ = np.array([x1_, y1_])
+        if verbose:
+            print("==== New in catalog 2 ====")
+            print(xy1_)
 
-            with open(diffcat2, 'a') as diffcat2_io:
-                for c_ in sew_out_table2.colnames:
-                    diffcat2_io.write(str(row1[c_]))
-                    diffcat2_io.write(" ")
-                diffcat2_io.write("\n")
+        with open(diffcat2, 'a') as diffcat2_io:
+            for c_ in sew_out_table2.colnames:
+                diffcat2_io.write(str(row1[c_]))
+                diffcat2_io.write(" ")
+            diffcat2_io.write("\n")
 
-            #xy_diff.append((xy1_+xy2_)/2.)
+        # xy_diff.append((xy1_+xy2_)/2.)
 
-            e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]),
-                            width=row1['A_IMAGE']*kr1,
-                            height=row1['B_IMAGE']*kr1,
-                            angle=row1['THETA_IMAGE'],
-                            linewidth=1, fill=False, alpha=0.9)
-            ax.add_artist(e)
-            e.set_clip_box(ax.bbox)
-            e.set_alpha(0.8)
-            e.set_color('y')
+        e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), width=row1['A_IMAGE'] * kr1,
+                    height=row1['B_IMAGE'] * kr1, angle=row1['THETA_IMAGE'], linewidth=1, fill=False, alpha=0.9)
+        ax.add_artist(e)
+        e.set_clip_box(ax.bbox)
+        e.set_alpha(0.8)
+        e.set_color('y')
 
-            #if row1['X_IMAGE'] <= 2100 and row1['X_IMAGE'] >= 1700 and row1['Y_IMAGE'] >= 880 and row1[
-            #    'Y_IMAGE'] <= 1250:
-            if row1['X_IMAGE'] <= PATTERN_LABEL_X_MAX and row1['X_IMAGE'] >= PATTERN_LABEL_X_MIN and row1[
-                    'Y_IMAGE'] >= PATTERN_LABEL_Y_MIN and row1[
-                    'Y_IMAGE'] <= PATTERN_LABEL_Y_MAX:
-                # print("Yo")
-                # print(int(row['ID']), row['X_IMAGE'], row['Y_IMAGE'])
-                ax.annotate(int(row1['ID']), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8, xycoords='data',
-                            xytext=(np.array([row1['X_IMAGE'] + row1['X_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[0] ,
-                                              row1['Y_IMAGE'] + row1['Y_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[1]])),  # for orig lens
-                            #xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])),  # for new lens
-                            color='c', alpha=0.8,
-                            arrowprops=dict(facecolor='c', edgecolor='c', shrink=0.05, headwidth=1, headlength=2,
-                                            width=0.5,
-                                            alpha=0.7),
-                            )
+        # if row1['X_IMAGE'] <= 2100 and row1['X_IMAGE'] >= 1700 and row1['Y_IMAGE'] >= 880 and row1[
+        #    'Y_IMAGE'] <= 1250:
+        if row1['X_IMAGE'] <= PATTERN_LABEL_X_MAX and row1['X_IMAGE'] >= PATTERN_LABEL_X_MIN and row1[
+            'Y_IMAGE'] >= PATTERN_LABEL_Y_MIN and row1['Y_IMAGE'] <= PATTERN_LABEL_Y_MAX:
+            # print("Yo")
+            # print(int(row['ID']), row['X_IMAGE'], row['Y_IMAGE'])
+            ax.annotate(int(row1['ID']), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8, xycoords='data',
+                        xytext=(np.array([row1['X_IMAGE'] + row1['X_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[0],
+                                          row1['Y_IMAGE'] + row1['Y_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[1]])),
+                        # for orig lens
+                        # xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])),  # for new lens
+                        color='c', alpha=0.8,
+                        arrowprops=dict(facecolor='c', edgecolor='c', shrink=0.05, headwidth=1, headlength=2, width=0.5,
+                                        alpha=0.7), )
 
-    #xy_common=np.array(xy_common)
-    #xy_diff=np.array(xy_diff)
-    #print(diff_ind1, diff_ind2)
-    #xy_common.shape #, xy_diff.shape
+    # xy_common=np.array(xy_common)
+    # xy_diff=np.array(xy_diff)
+    # print(diff_ind1, diff_ind2)
+    # xy_common.shape #, xy_diff.shape
     if verbose:
         print("Common indices")
         print(commond_ind1, commond_ind2)
@@ -1051,8 +978,7 @@ def naive_comparison(sew_out_table1, sew_out_table2, im1, im2,
     if cropys is not None:
         plt.ylim(cropys)
     plt.plot([center[0]], [center[1]], 'g+')
-    plt.scatter(x_corners,
-                y_corners, s=20, facecolors='none', edgecolors='m')
+    plt.scatter(x_corners, y_corners, s=20, facecolors='none', edgecolors='m')
 
     if outfile2 is not None:
         plt.savefig(outfile2)
@@ -1060,8 +986,8 @@ def naive_comparison(sew_out_table1, sew_out_table2, im1, im2,
     fig, ax = plt.subplots(subplot_kw={'aspect': 'equal'})
 
     max_pixel_crop1 = np.max(im1[cropys[1]:cropys[0], cropxs[0]:cropxs[1]])
-    #print("Brightest pixel in the zoomed area in image 1 reaches {}".format(max_pixel_crop1))
-    #if max_pixel_crop1 == 255:
+    # print("Brightest pixel in the zoomed area in image 1 reaches {}".format(max_pixel_crop1))
+    # if max_pixel_crop1 == 255:
     #    print("Image 1 is saturated. ")
 
     ax_img = ax.imshow(im1, cmap='gray', vmax=max_pixel_crop1)
@@ -1069,108 +995,96 @@ def naive_comparison(sew_out_table1, sew_out_table2, im1, im2,
 
     i1 = -1
     for row1 in sew_out_table1:
-            i1+=1
-            x1_ = row1['X_IMAGE']
-            y1_ = row1['Y_IMAGE']
-            f1_ = row1['FLUX_ISO']
-            kr1 = row1['KRON_RADIUS']
-            xy1_ = np.array([x1_, y1_])
+        i1 += 1
+        x1_ = row1['X_IMAGE']
+        y1_ = row1['Y_IMAGE']
+        f1_ = row1['FLUX_ISO']
+        kr1 = row1['KRON_RADIUS']
+        xy1_ = np.array([x1_, y1_])
 
-            dist_ = np.linalg.norm(xy1_-xy2_)
-            if i1 in commond_ind1:
-                e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]),
-                            width=row1['A_IMAGE']*kr1,
-                            height=row1['B_IMAGE']*kr1,
-                            angle=row1['THETA_IMAGE'],
-                            linewidth=1, fill=False, alpha=0.9)
-                ax.add_artist(e)
-                e.set_clip_box(ax.bbox)
-                e.set_alpha(0.8)
-                e.set_color('r')
-
-                #if row1['X_IMAGE'] <= 2100 and row1['X_IMAGE'] >= 1700 and row1['Y_IMAGE'] >= 880 and row1[
-                #    'Y_IMAGE'] <= 1250:
-                if row1['X_IMAGE'] <= PATTERN_LABEL_X_MAX and row1['X_IMAGE'] >= PATTERN_LABEL_X_MIN and row1[
-                    'Y_IMAGE'] >= PATTERN_LABEL_Y_MIN and row1[
-                    'Y_IMAGE'] <= PATTERN_LABEL_Y_MAX:
-                    # print("Yo")
-                    # print(int(row['ID']), row['X_IMAGE'], row['Y_IMAGE'])
-                    ax.annotate(int(row1['ID']), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8,
-                                xycoords='data',
-                                xytext=(np.array([row1['X_IMAGE'] + row1['X_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[0],
-                                                  row1['Y_IMAGE'] + row1['Y_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[1]])),  # for orig lens
-
-                                #xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])),  # for new lens
-                                color='c', alpha=0.8,
-                                arrowprops=dict(facecolor='c', edgecolor='c', shrink=0.05, headwidth=1, headlength=2,
-                                                width=0.5,
-                                                alpha=0.7),
-                                )
-
-    i1 = -1
-    for row1 in sew_out_table1:
-            i1+=1
-            if i1 not in diff_ind1:
-                continue
-
-            x1_ = row1['X_IMAGE']
-            y1_ = row1['Y_IMAGE']
-            f1_ = row1['FLUX_ISO']
-            kr1 = row1['KRON_RADIUS']
-            xy1_ = np.array([x1_, y1_])
-            #xy_diff.append((xy1_+xy2_)/2.)
-            if verbose:
-                print("==== New in catalog 1 ====")
-                print(xy1_)
-            with open(diffcat1, 'a') as diffcat1_io:
-                for c_ in sew_out_table1.colnames:
-                    diffcat1_io.write(str(row1[c_]))
-                    diffcat1_io.write(" ")
-                diffcat1_io.write("\n")
-            e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]),
-                            width=row1['A_IMAGE']*kr1,
-                            height=row1['B_IMAGE']*kr1,
-                            angle=row1['THETA_IMAGE'],
-                            linewidth=1, fill=False, alpha=0.9)
+        dist_ = np.linalg.norm(xy1_ - xy2_)
+        if i1 in commond_ind1:
+            e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), width=row1['A_IMAGE'] * kr1,
+                        height=row1['B_IMAGE'] * kr1, angle=row1['THETA_IMAGE'], linewidth=1, fill=False, alpha=0.9)
             ax.add_artist(e)
             e.set_clip_box(ax.bbox)
             e.set_alpha(0.8)
-            e.set_color('g')
-            #if row1['X_IMAGE'] <= 2100 and row1['X_IMAGE'] >= 1700 and row1['Y_IMAGE'] >= 880 and row1[
+            e.set_color('r')
+
+            # if row1['X_IMAGE'] <= 2100 and row1['X_IMAGE'] >= 1700 and row1['Y_IMAGE'] >= 880 and row1[
             #    'Y_IMAGE'] <= 1250:
             if row1['X_IMAGE'] <= PATTERN_LABEL_X_MAX and row1['X_IMAGE'] >= PATTERN_LABEL_X_MIN and row1[
-                'Y_IMAGE'] >= PATTERN_LABEL_Y_MIN and row1[
-                'Y_IMAGE'] <= PATTERN_LABEL_Y_MAX:
+                'Y_IMAGE'] >= PATTERN_LABEL_Y_MIN and row1['Y_IMAGE'] <= PATTERN_LABEL_Y_MAX:
                 # print("Yo")
                 # print(int(row['ID']), row['X_IMAGE'], row['Y_IMAGE'])
                 ax.annotate(int(row1['ID']), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8, xycoords='data',
-                            xytext=(np.array([row1['X_IMAGE'] + row1['X_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[0] ,
-                                              row1['Y_IMAGE'] + row1['Y_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[1]])),  # for orig lens
-                            #xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])),  # for new lens
+                            xytext=(np.array([row1['X_IMAGE'] + row1['X_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[0],
+                                              row1['Y_IMAGE'] + row1['Y_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[
+                                                  1]])),  # for orig lens
+
+                            # xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])),  # for new lens
                             color='c', alpha=0.8,
                             arrowprops=dict(facecolor='c', edgecolor='c', shrink=0.05, headwidth=1, headlength=2,
-                                            width=0.5,
-                                            alpha=0.7),
-                            )
+                                            width=0.5, alpha=0.7), )
+
+    i1 = -1
+    for row1 in sew_out_table1:
+        i1 += 1
+        if i1 not in diff_ind1:
+            continue
+
+        x1_ = row1['X_IMAGE']
+        y1_ = row1['Y_IMAGE']
+        f1_ = row1['FLUX_ISO']
+        kr1 = row1['KRON_RADIUS']
+        xy1_ = np.array([x1_, y1_])
+        # xy_diff.append((xy1_+xy2_)/2.)
+        if verbose:
+            print("==== New in catalog 1 ====")
+            print(xy1_)
+        with open(diffcat1, 'a') as diffcat1_io:
+            for c_ in sew_out_table1.colnames:
+                diffcat1_io.write(str(row1[c_]))
+                diffcat1_io.write(" ")
+            diffcat1_io.write("\n")
+        e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), width=row1['A_IMAGE'] * kr1,
+                    height=row1['B_IMAGE'] * kr1, angle=row1['THETA_IMAGE'], linewidth=1, fill=False, alpha=0.9)
+        ax.add_artist(e)
+        e.set_clip_box(ax.bbox)
+        e.set_alpha(0.8)
+        e.set_color('g')
+        # if row1['X_IMAGE'] <= 2100 and row1['X_IMAGE'] >= 1700 and row1['Y_IMAGE'] >= 880 and row1[
+        #    'Y_IMAGE'] <= 1250:
+        if row1['X_IMAGE'] <= PATTERN_LABEL_X_MAX and row1['X_IMAGE'] >= PATTERN_LABEL_X_MIN and row1[
+            'Y_IMAGE'] >= PATTERN_LABEL_Y_MIN and row1['Y_IMAGE'] <= PATTERN_LABEL_Y_MAX:
+            # print("Yo")
+            # print(int(row['ID']), row['X_IMAGE'], row['Y_IMAGE'])
+            ax.annotate(int(row1['ID']), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8, xycoords='data',
+                        xytext=(np.array([row1['X_IMAGE'] + row1['X_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[0],
+                                          row1['Y_IMAGE'] + row1['Y_IMAGE'] - PATTERN_CENTER_FROM_LABEL_BOUNDS[1]])),
+                        # for orig lens
+                        # xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])),  # for new lens
+                        color='c', alpha=0.8,
+                        arrowprops=dict(facecolor='c', edgecolor='c', shrink=0.05, headwidth=1, headlength=2, width=0.5,
+                                        alpha=0.7), )
 
     if cropxs is not None:
         plt.xlim(cropxs)
     if cropys is not None:
         plt.ylim(cropys)
 
-    #mark center and corners:
+    # mark center and corners:
     plt.plot([center[0]], [center[1]], 'g+')
-    plt.scatter(x_corners,
-                y_corners, s=20, facecolors='none', edgecolors='m')
+    plt.scatter(x_corners, y_corners, s=20, facecolors='none', edgecolors='m')
 
     if outfile1 is not None:
         plt.savefig(outfile1)
 
 
-def calc_dist(cat1, cat2, n1, n2, pix2mm = 0.48244):
+def calc_dist(cat1, cat2, n1, n2, pix2mm=0.48244):
     dx = (cat2.loc[n2]['X_IMAGE'] - cat1.loc[n1]['X_IMAGE'])
     dy = (cat2.loc[n2]['Y_IMAGE'] - cat1.loc[n1]['Y_IMAGE'])
-    dist_pix = np.sqrt(dx**2 + dy**2)
+    dist_pix = np.sqrt(dx ** 2 + dy ** 2)
     dist_mm = dist_pix * pix2mm
     print("centroid moved in x {:.4f} pix and in y {:.4f} pix".format(dx, dy))
     print("centroid moved by distance {:.4f} pix = {:.4f} mm".format(dist_pix, dist_mm))
@@ -1178,17 +1092,12 @@ def calc_dist(cat1, cat2, n1, n2, pix2mm = 0.48244):
     return dx, dy, dist_pix
 
 
-def plot_diff_labelled(rawf1, rawf2, cat1, cat2,
-                       ind1=None, ind2=None,
-                       motion_outfile_prefix="motion_output",
-                       outfile1="new_label1.pdf", outfile2="new_label2.pdf",
-                       cropxs=(1350, 1800), cropys=(1250, 800),
-                       center = np.array([1891.25, 1063.75])
-    ):
-
+def plot_diff_labelled(rawf1, rawf2, cat1, cat2, ind1=None, ind2=None, motion_outfile_prefix="motion_output",
+                       outfile1="new_label1.pdf", outfile2="new_label2.pdf", cropxs=(1350, 1800), cropys=(1250, 800),
+                       center=np.array([1891.25, 1063.75])):
     x_corners, y_corners = get_central_mod_corners(center=center)
 
-    #cat1 and cat2 are the * diff * cats
+    # cat1 and cat2 are the * diff * cats
     im1 = read_raw(rawf1)
     im2 = read_raw(rawf2)
 
@@ -1199,8 +1108,8 @@ def plot_diff_labelled(rawf1, rawf2, cat1, cat2,
     cat1 = pd.read_csv(cat1, sep=r"\s+")
     cat2 = pd.read_csv(cat2, sep=r"\s+")
 
-    #cat1_screen = cat1[(cat1.X_IMAGE >= np.min(x_corners)) & (cat1.X_IMAGE <= np.max(x_corners))]
-    #cat2_screen = cat1[(cat2.Y_IMAGE >= np.min(y_corners)) & (cat2.Y_IMAGE <= np.max(y_corners))]
+    # cat1_screen = cat1[(cat1.X_IMAGE >= np.min(x_corners)) & (cat1.X_IMAGE <= np.max(x_corners))]
+    # cat2_screen = cat1[(cat2.Y_IMAGE >= np.min(y_corners)) & (cat2.Y_IMAGE <= np.max(y_corners))]
 
     fig, ax = plt.subplots(subplot_kw={'aspect': 'equal'})
 
@@ -1209,14 +1118,15 @@ def plot_diff_labelled(rawf1, rawf2, cat1, cat2,
     if max_pixel_crop1 == 255:
         sat_pix = np.sum(im1 == 255)
         percent_satur = 100.0 * sat_pix / (cropys[0] - cropys[1]) / (cropxs[1] - cropxs[0])
-        print("{:.3f}% of the pixels (= {} pixels) in zoomed area of image 1 is saturated. ".format(percent_satur, sat_pix))
+        print("{:.3f}% of the pixels (= {} pixels) in zoomed area of image 1 is saturated. ".format(percent_satur,
+                                                                                                    sat_pix))
 
     ax_img = ax.imshow(im1, cmap='gray', vmax=max_pixel_crop1)
-    #ax_img = ax.imshow(im1, cmap='gray')
+    # ax_img = ax.imshow(im1, cmap='gray')
     fig.colorbar(ax_img)
 
     if ind1 is not None:
-        motion_outfile = motion_outfile_prefix+"ind"+str(ind1)+"_ind"+str(ind2)+".txt"
+        motion_outfile = motion_outfile_prefix + "ind" + str(ind1) + "_ind" + str(ind2) + ".txt"
 
         row1 = cat1.loc[ind1]
         with open(motion_outfile, 'w') as io_:
@@ -1228,41 +1138,35 @@ def plot_diff_labelled(rawf1, rawf2, cat1, cat2,
                 io_.write(" ")
             io_.write("\n")
         kr = row1['KRON_RADIUS']
-        e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]),
-                    width=row1['A_IMAGE']*kr,
-                    height=row1['B_IMAGE']*kr,
-                    angle=row1['THETA_IMAGE'],
-                    linewidth=1, fill=False, alpha=0.9)
+        e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), width=row1['A_IMAGE'] * kr,
+                    height=row1['B_IMAGE'] * kr, angle=row1['THETA_IMAGE'], linewidth=1, fill=False, alpha=0.9)
         ax.add_artist(e)
         e.set_clip_box(ax.bbox)
         e.set_alpha(0.8)
         e.set_color('g')
-        #ax.annotate(str(ind1), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8,
+        # ax.annotate(str(ind1), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8,
         ax.annotate(int(row1['ID']), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8,
-                    #xytext=(np.array([row1['X_IMAGE'] - 40, row1['Y_IMAGE'] - 40])), #for orig lens
-                    xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])), # for new lens
+                    # xytext=(np.array([row1['X_IMAGE'] - 40, row1['Y_IMAGE'] - 40])), #for orig lens
+                    xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])),  # for new lens
                     color='g', alpha=0.8,
-                    arrowprops=dict(facecolor='g', edgecolor='g', shrink=0.05, headwidth=1, headlength=4, width=0.5, alpha=0.7),
-                    )
+                    arrowprops=dict(facecolor='g', edgecolor='g', shrink=0.05, headwidth=1, headlength=4, width=0.5,
+                                    alpha=0.7), )
     else:
         for i, row1 in cat1.iterrows():
             kr = row1['KRON_RADIUS']
-            e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]),
-                        width=row1['A_IMAGE']*kr,
-                        height=row1['B_IMAGE']*kr,
-                        angle=row1['THETA_IMAGE'],
-                        linewidth=1, fill=False, alpha=0.9)
+            e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), width=row1['A_IMAGE'] * kr,
+                        height=row1['B_IMAGE'] * kr, angle=row1['THETA_IMAGE'], linewidth=1, fill=False, alpha=0.9)
             ax.add_artist(e)
             e.set_clip_box(ax.bbox)
             e.set_alpha(0.8)
             e.set_color('g')
-            #ax.annotate(str(i), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]),size=8,
+            # ax.annotate(str(i), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]),size=8,
             ax.annotate(int(row1['ID']), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8,
-                        #xytext=(np.array([row1['X_IMAGE'] - 40, row1['Y_IMAGE'] - 40])), #for orig lens
-                        xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])), # for new lens
+                        # xytext=(np.array([row1['X_IMAGE'] - 40, row1['Y_IMAGE'] - 40])), #for orig lens
+                        xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])),  # for new lens
                         color='g', alpha=0.8,
-                        arrowprops=dict(facecolor='g', edgecolor='g', shrink=0.05, headwidth=1, headlength=4, width=0.5, alpha=0.7),
-                        )
+                        arrowprops=dict(facecolor='g', edgecolor='g', shrink=0.05, headwidth=1, headlength=4, width=0.5,
+                                        alpha=0.7), )
 
     if cropxs is not None:
         plt.xlim(cropxs)
@@ -1270,25 +1174,23 @@ def plot_diff_labelled(rawf1, rawf2, cat1, cat2,
         plt.ylim(cropys)
 
     plt.plot([center[0]], [center[1]], 'g+')
-    plt.scatter(x_corners,
-                y_corners, s=20, facecolors='none', edgecolors='m')
+    plt.scatter(x_corners, y_corners, s=20, facecolors='none', edgecolors='m')
 
     plt.tight_layout()
-    #plt.xlim(1170, 1970)
-    #plt.ylim(1410, 610)
+    # plt.xlim(1170, 1970)
+    # plt.ylim(1410, 610)
 
     plt.savefig(outfile1)
 
-    #plt.show()
+    # plt.show()
 
     max_pixel_crop2 = np.max(im2[cropys[1]:cropys[0], cropxs[0]:cropxs[1]])
     print("Brightest pixel in the zoomed area in image 2 reaches {}".format(max_pixel_crop2))
     if max_pixel_crop2 == 255:
         sat_pix = np.sum(im2 == 255)
         percent_satur = 100.0 * sat_pix / (cropys[0] - cropys[1]) / (cropxs[1] - cropxs[0])
-        print(
-        "{:.3f}% of the pixels (= {} pixels) in zoomed area of image 2 is saturated. ".format(percent_satur, sat_pix))
-
+        print("{:.3f}% of the pixels (= {} pixels) in zoomed area of image 2 is saturated. ".format(percent_satur,
+                                                                                                    sat_pix))
 
     fig, ax = plt.subplots(subplot_kw={'aspect': 'equal'})
     ax_img = ax.imshow(im2, cmap='gray', vmax=max_pixel_crop2)
@@ -1304,41 +1206,35 @@ def plot_diff_labelled(rawf1, rawf2, cat1, cat2,
                 io_.write(" ")
             io_.write("\n")
         kr = row1['KRON_RADIUS']
-        e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]),
-                    width=row1['A_IMAGE']*kr,
-                    height=row1['B_IMAGE']*kr,
-                    angle=row1['THETA_IMAGE'],
-                    linewidth=1, fill=False, alpha=0.9)
+        e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), width=row1['A_IMAGE'] * kr,
+                    height=row1['B_IMAGE'] * kr, angle=row1['THETA_IMAGE'], linewidth=1, fill=False, alpha=0.9)
         ax.add_artist(e)
         e.set_clip_box(ax.bbox)
         e.set_alpha(0.8)
         e.set_color('y')
-        #ax.annotate(str(ind2), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8,
+        # ax.annotate(str(ind2), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8,
         ax.annotate(int(row1['ID']), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8,
-                    #xytext=(np.array([row1['X_IMAGE'] - 40, row1['Y_IMAGE'] - 40])), # for orig lens
-                    xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])), # for new lens
-                    color='y',alpha=0.8,
-                    arrowprops=dict(facecolor='y', edgecolor='y', shrink=0.05, headwidth=1, headlength=4, width=0.5, alpha=0.7),
-                    )
+                    # xytext=(np.array([row1['X_IMAGE'] - 40, row1['Y_IMAGE'] - 40])), # for orig lens
+                    xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])),  # for new lens
+                    color='y', alpha=0.8,
+                    arrowprops=dict(facecolor='y', edgecolor='y', shrink=0.05, headwidth=1, headlength=4, width=0.5,
+                                    alpha=0.7), )
     else:
         for i, row1 in cat2.iterrows():
             kr = row1['KRON_RADIUS']
-            e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]),
-                        width=row1['A_IMAGE']*kr,
-                        height=row1['B_IMAGE']*kr,
-                        angle=row1['THETA_IMAGE'],
-                        linewidth=1, fill=False, alpha=0.9)
+            e = Ellipse(xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), width=row1['A_IMAGE'] * kr,
+                        height=row1['B_IMAGE'] * kr, angle=row1['THETA_IMAGE'], linewidth=1, fill=False, alpha=0.9)
             ax.add_artist(e)
             e.set_clip_box(ax.bbox)
             e.set_alpha(0.8)
             e.set_color('y')
-            #ax.annotate(str(i), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8,
+            # ax.annotate(str(i), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8,
             ax.annotate(int(row1['ID']), xy=np.array([row1['X_IMAGE'], row1['Y_IMAGE']]), size=8,
-                        #xytext=(np.array([row1['X_IMAGE'] - 40, row1['Y_IMAGE'] - 40])), # for orig lens
-                        xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])), # for new lens
+                        # xytext=(np.array([row1['X_IMAGE'] - 40, row1['Y_IMAGE'] - 40])), # for orig lens
+                        xytext=(np.array([row1['X_IMAGE'] - 80, row1['Y_IMAGE'] - 80])),  # for new lens
                         color='y', alpha=0.8,
-                        arrowprops=dict(facecolor='y', edgecolor='y', shrink=0.05, headwidth=1, headlength=4, width=0.5,alpha=0.7 ),
-                        )
+                        arrowprops=dict(facecolor='y', edgecolor='y', shrink=0.05, headwidth=1, headlength=4, width=0.5,
+                                        alpha=0.7), )
 
     if cropxs is not None:
         plt.xlim(cropxs)
@@ -1346,15 +1242,14 @@ def plot_diff_labelled(rawf1, rawf2, cat1, cat2,
         plt.ylim(cropys)
 
     plt.plot([center[0]], [center[1]], 'g+')
-    plt.scatter(x_corners,
-                y_corners, s=20, facecolors='none', edgecolors='m')
+    plt.scatter(x_corners, y_corners, s=20, facecolors='none', edgecolors='m')
 
     plt.tight_layout()
-    #plt.xlim(1170, 1970)
-    #plt.ylim(1410, 610)
+    # plt.xlim(1170, 1970)
+    # plt.ylim(1410, 610)
 
     plt.savefig(outfile2)
-    #plt.show()
+    # plt.show()
 
     if ind1 is not None and ind2 is not None:
         dx, dy, dist_pix = calc_dist(cat1, cat2, ind1, ind2)
@@ -1372,8 +1267,8 @@ def get_datetime_rawname(raw_name):
 
 
 def yes_or_no(question):
-    #from builtins import input
-    reply = str(input(question+' (y/n): ')).lower().strip()
+    # from builtins import input
+    reply = str(input(question + ' (y/n): ')).lower().strip()
     if reply[0] == 'y':
         return True
     if reply[0] == 'n':
@@ -1383,45 +1278,44 @@ def yes_or_no(question):
 
 
 def grid2gif(im1, im2, output_gif):
-    str1 = 'convert -delay 50 -loop 0 -quality 100 -density 144 ' + im1 +' ' + im2  + ' ' + output_gif
+    str1 = 'convert -delay 50 -loop 0 -quality 100 -density 144 ' + im1 + ' ' + im2 + ' ' + output_gif
     subprocess.call(str1, shell=True)
 
 
 def main():
     parser = argparse.ArgumentParser(description='Compare two raw images of stars at the focal plane')
 
-    parser.add_argument('rawfile1',type=str)
-    parser.add_argument('rawfile2',type=str, default=None, nargs='?')
+    parser.add_argument('rawfile1', type=str)
+    parser.add_argument('rawfile2', type=str, default=None, nargs='?')
 
     parser.add_argument('--DETECT_MINAREA', type=int, default=30, help="+++ Important parameter +++: "
                                                                        "Config param for sextractor, our default is 30.")
     parser.add_argument('--THRESH', type=int, default=6, help="+++ Important parameter +++: "
                                                               "Config param for sextractor, our default is 6.")
     parser.add_argument('--DEBLEND_MINCONT', type=float, default=0.01, help="+++ Important parameter +++: "
-                                                              "Config param for sextractor, our default is 0.01 "
-                                                                         "The smaller this number is, the harder we try to "
-                                                                         "deblend, i.e. to separate overlaying objects. ")
-    parser.add_argument('--kernel_w', type=int, default=3, help="If you have cv2, this is the median blurring kernel width"
-                                                                "our default is 3 (for a 3x3 kernel).")
+                                                                            "Config param for sextractor, our default is 0.01 "
+                                                                            "The smaller this number is, the harder we try to "
+                                                                            "deblend, i.e. to separate overlaying objects. ")
+    parser.add_argument('--kernel_w', type=int, default=3,
+                        help="If you have cv2, this is the median blurring kernel width"
+                             "our default is 3 (for a 3x3 kernel).")
 
     parser.add_argument('--min_dist', type=float, default=20, help="+++ Important parameter +++: "
                                                                    "Minimum distance we use to conclude a centroid is common in both images"
                                                                    "our default is 20 pixels.")
 
-    parser.add_argument('--save_filename_prefix1', default=None,
-                        help="File name prefix of the output files, "
-                             "this will automatically populate savefits_name1, saveplot_name1, savecatalog_name1, and diffcatalog_name1"
-                             "default is None.")
+    parser.add_argument('--save_filename_prefix1', default=None, help="File name prefix of the output files, "
+                                                                      "this will automatically populate savefits_name1, saveplot_name1, savecatalog_name1, and diffcatalog_name1"
+                                                                      "default is None.")
 
-    parser.add_argument('--save_filename_prefix2', default=None,
-                        help="File name prefix of the output files, "
-                             "this will automatically populate savefits_name2, saveplot_name2, savecatalog_name2, and diffcatalog_name2"
-                             "default is None.")
+    parser.add_argument('--save_filename_prefix2', default=None, help="File name prefix of the output files, "
+                                                                      "this will automatically populate savefits_name2, saveplot_name2, savecatalog_name2, and diffcatalog_name2"
+                                                                      "default is None.")
 
-    parser.add_argument('--savefits_name1',default=None,
+    parser.add_argument('--savefits_name1', default=None,
                         help="File name of the fits for the first image if you want to choose, "
                              "default has the same name as raw.")
-    parser.add_argument('--saveplot_name1',default=None,
+    parser.add_argument('--saveplot_name1', default=None,
                         help="File name of the image (jpeg or pdf etc) for the first image if you want to choose, "
                              "default is not to save it.")
     parser.add_argument('--savefits_name2', default=None,
@@ -1450,26 +1344,20 @@ def main():
                              "default is diff_cat2.pdf.")
     parser.add_argument('--datadir', default="data",
                         help="Folder to save all output files. Default is ./data (ignored by git)")
-    parser.add_argument('--gifname', default=None, #default="compare.gif",
+    parser.add_argument('--gifname', default=None,  # default="compare.gif",
                         help="File name to save gif animation. ")
 
-    parser.add_argument('--cropx1',
-                        default=1050,
-                        #default=1170,
+    parser.add_argument('--cropx1', default=1050,  # default=1170,
                         # default=(1350, 1800),
                         help="zooming into xlim that you want to plot, use None for no zoom, default is (1650, 2100).")
-    parser.add_argument('--cropx2',
-                        default=2592,
-                        #default=1970,
+    parser.add_argument('--cropx2', default=2592,  # default=1970,
                         # default=(1350, 1800),
                         help="zooming into xlim that you want to plot, use None for no zoom, default is (1650, 2100).")
 
-    parser.add_argument('--cropy1',
-                        #default=1410,
+    parser.add_argument('--cropy1',  # default=1410,
                         default=1850,
                         help="zooming into ylim that you want to plot, use None for no zoom, default is (1250, 800).")
-    parser.add_argument('--cropy2',
-                        #default=610,
+    parser.add_argument('--cropy2',  # default=610,
                         default=250,
                         help="zooming into ylim that you want to plot, use None for no zoom, default is (1250, 800).")
 
@@ -1483,17 +1371,22 @@ def main():
     parser.add_argument('-r', '--ring', action='store_true', help="Try to find a ring.")
     parser.add_argument('--clustering', action='store_true')
 
-    parser.add_argument('-C', '--center', nargs = 2, type = float, default=[1891.25, 1063.75], help="Center coordinate X_pix Y_pix. ")
-    parser.add_argument('-p', '--pattern_center', nargs = 2, type = float, default=[1891.25, 1063.75], help="Center coordinate for ring pattern X_pix Y_pix. ")
-    parser.add_argument('--ring_rad', type = float, default=32 / PIX2MM, help="Radius in pixels for ring pattern. ")
-    parser.add_argument('--ring_tol', type = float, default=0.1)
-    parser.add_argument('--phase_offset_rad', type = float, default=0.)
-    parser.add_argument('--ring_frac', type = float, default=0.3, help="Fraction (1-frac, 1+frac)*radius that you accept a centroid "
-                                                                       "as part of a ring pattern. ")
+    parser.add_argument('-C', '--center', nargs=2, type=float, default=[1891.25, 1063.75],
+                        help="Center coordinate X_pix Y_pix. ")
+    parser.add_argument('-p', '--pattern_center', nargs=2, type=float, default=[1891.25, 1063.75],
+                        help="Center coordinate for ring pattern X_pix Y_pix. ")
+    parser.add_argument('--ring_rad', type=float, default=32 / PIX2MM, help="Radius in pixels for ring pattern. ")
+    parser.add_argument('--ring_tol', type=float, default=0.1)
+    parser.add_argument('--phase_offset_rad', type=float, default=0.)
+    parser.add_argument('--ring_frac', type=float, default=0.3,
+                        help="Fraction (1-frac, 1+frac)*radius that you accept a centroid "
+                             "as part of a ring pattern. ")
 
     parser.add_argument('--ring_file', default=None, help="File name for ring pattern. ")
-    parser.add_argument('--search_xs', nargs = 2, type = float, default=[0, 0], help="Xmin and Xmax to list all centroid in a box. ")
-    parser.add_argument('--search_ys', nargs = 2, type = float, default=[0, 0], help="Ymin and Ymax to list all centroid in a box. ")
+    parser.add_argument('--search_xs', nargs=2, type=float, default=[0, 0],
+                        help="Xmin and Xmax to list all centroid in a box. ")
+    parser.add_argument('--search_ys', nargs=2, type=float, default=[0, 0],
+                        help="Ymin and Ymax to list all centroid in a box. ")
     parser.add_argument('--quick_ring_check', default=None, help="Do ring check; dubs as file name for ring pattern. ")
     parser.add_argument("--show", action='store_true')
     parser.add_argument("--get_center", action='store_true')
@@ -1501,8 +1394,8 @@ def main():
     args = parser.parse_args()
 
     if args.nozoom:
-        cropxs=None
-        cropys=None
+        cropxs = None
+        cropys = None
     else:
         cropxs = (args.cropx1, args.cropx2)
         cropys = (args.cropy1, args.cropy2)
@@ -1518,27 +1411,27 @@ def main():
     ring_file = None
 
     if args.save_filename_prefix1 is not None:
-        savefits_name1 = os.path.join(args.datadir, args.save_filename_prefix1+'_im1.fits')
-        savecatalog_name1 = os.path.join(args.datadir,args.save_filename_prefix1+'_cat1.txt')
-        saveplot_name1 = os.path.join(args.datadir,args.save_filename_prefix1+'_cat1.pdf')
-        diffcatalog_name1 = os.path.join(args.datadir,args.save_filename_prefix1 + "_diff_cat1.txt")
-        diffplot_name1 = os.path.join(args.datadir,args.save_filename_prefix1 + "_diff_cat1.pdf")
-        motion_outfile_prefix =  os.path.join(args.datadir,args.save_filename_prefix1)
+        savefits_name1 = os.path.join(args.datadir, args.save_filename_prefix1 + '_im1.fits')
+        savecatalog_name1 = os.path.join(args.datadir, args.save_filename_prefix1 + '_cat1.txt')
+        saveplot_name1 = os.path.join(args.datadir, args.save_filename_prefix1 + '_cat1.pdf')
+        diffcatalog_name1 = os.path.join(args.datadir, args.save_filename_prefix1 + "_diff_cat1.txt")
+        diffplot_name1 = os.path.join(args.datadir, args.save_filename_prefix1 + "_diff_cat1.pdf")
+        motion_outfile_prefix = os.path.join(args.datadir, args.save_filename_prefix1)
         save_filename_prefix1 = args.save_filename_prefix1
         if args.ring_file is None:
             ring_file = save_filename_prefix1 + "_ring_search_1.pdf"
             ring_cat_file = save_filename_prefix1 + "_ring_search_1.txt"
         else:
-            ring_file =  os.path.join(args.datadir, args.ring_file)
-            ring_cat_file = os.path.join(args.datadir, args.ring_file[:-4]+".txt")
+            ring_file = os.path.join(args.datadir, args.ring_file)
+            ring_cat_file = os.path.join(args.datadir, args.ring_file[:-4] + ".txt")
         vvv_ring_file = save_filename_prefix1 + "_ring_search_vvv.csv"
     elif args.savefits_name1 is None or args.savecatalog_name1 is None or args.diffcatalog_name1 is None or args.diffplot_name1 is None:
         dt_match = get_datetime_rawname(args.rawfile1)
         print("Using default output file names with date {}".format(dt_match))
-        save_filename_prefix1 = os.path.join(args.datadir,"res_focal_plane_"+dt_match)
-        savefits_name1 = save_filename_prefix1+'_im1.fits'
-        savecatalog_name1 = save_filename_prefix1+'_cat1.txt'
-        saveplot_name1 = save_filename_prefix1+'_cat1.pdf'
+        save_filename_prefix1 = os.path.join(args.datadir, "res_focal_plane_" + dt_match)
+        savefits_name1 = save_filename_prefix1 + '_im1.fits'
+        savecatalog_name1 = save_filename_prefix1 + '_cat1.txt'
+        saveplot_name1 = save_filename_prefix1 + '_cat1.pdf'
         diffcatalog_name1 = save_filename_prefix1 + "_diff_cat1.txt"
         diffplot_name1 = save_filename_prefix1 + "_diff_cat1.pdf"
         motion_outfile_prefix = save_filename_prefix1
@@ -1546,29 +1439,29 @@ def main():
             ring_file = save_filename_prefix1 + "_ring_search_1.pdf"
             ring_cat_file = save_filename_prefix1 + "_ring_search_1.txt"
         else:
-            ring_file =  os.path.join(args.datadir, args.ring_file)
-            ring_cat_file = os.path.join(args.datadir, args.ring_file[:-4]+".txt")
+            ring_file = os.path.join(args.datadir, args.ring_file)
+            ring_cat_file = os.path.join(args.datadir, args.ring_file[:-4] + ".txt")
         vvv_ring_file = save_filename_prefix1 + "_ring_search_vvv.csv"
     else:
-        savefits_name1 = os.path.join(args.datadir,args.savefits_name1)
-        savecatalog_name1 = os.path.join(args.datadir,args.savecatalog_name1)
-        saveplot_name1 = os.path.join(args.datadir,args.saveplot_name1)
-        diffcatalog_name1 = os.path.join(args.datadir,args.diffcatalog_name1)
-        diffplot_name1 = os.path.join(args.datadir,args.diffplot_name1)
-        motion_outfile_prefix = os.path.join(args.datadir,args.motion_outfile_prefix)
+        savefits_name1 = os.path.join(args.datadir, args.savefits_name1)
+        savecatalog_name1 = os.path.join(args.datadir, args.savecatalog_name1)
+        saveplot_name1 = os.path.join(args.datadir, args.saveplot_name1)
+        diffcatalog_name1 = os.path.join(args.datadir, args.diffcatalog_name1)
+        diffplot_name1 = os.path.join(args.datadir, args.diffplot_name1)
+        motion_outfile_prefix = os.path.join(args.datadir, args.motion_outfile_prefix)
     if args.rawfile2 is not None:
         if args.save_filename_prefix2 is not None:
-            savefits_name2 = os.path.join(args.datadir,args.save_filename_prefix2 + '_im2.fits')
-            savecatalog_name2 = os.path.join(args.datadir,args.save_filename_prefix2 + '_cat2.txt')
-            saveplot_name2 = os.path.join(args.datadir,args.save_filename_prefix2 + '_cat2.pdf')
-            diffcatalog_name2 = os.path.join(args.datadir,args.save_filename_prefix2 + "_diff_cat2.txt")
-            diffplot_name2 = os.path.join(args.datadir,args.save_filename_prefix2 + "_diff_cat2.pdf")
-            motion_outfile_prefix =  motion_outfile_prefix + "_" + args.save_filename_prefix2 + "_motion.txt"
+            savefits_name2 = os.path.join(args.datadir, args.save_filename_prefix2 + '_im2.fits')
+            savecatalog_name2 = os.path.join(args.datadir, args.save_filename_prefix2 + '_cat2.txt')
+            saveplot_name2 = os.path.join(args.datadir, args.save_filename_prefix2 + '_cat2.pdf')
+            diffcatalog_name2 = os.path.join(args.datadir, args.save_filename_prefix2 + "_diff_cat2.txt")
+            diffplot_name2 = os.path.join(args.datadir, args.save_filename_prefix2 + "_diff_cat2.pdf")
+            motion_outfile_prefix = motion_outfile_prefix + "_" + args.save_filename_prefix2 + "_motion.txt"
             gifname = motion_outfile_prefix + "_" + args.save_filename_prefix2 + "_anime.gif"
         elif args.savefits_name2 is None or args.savecatalog_name2 is None or args.diffcatalog_name2 is None or args.diffplot_name2 is None:
             dt_match = get_datetime_rawname(args.rawfile2)
             print("Using default output file names with date {}".format(dt_match))
-            save_filename_prefix2 = os.path.join(args.datadir,"res_focal_plane_" + dt_match)
+            save_filename_prefix2 = os.path.join(args.datadir, "res_focal_plane_" + dt_match)
             savefits_name2 = save_filename_prefix2 + '_im2.fits'
             savecatalog_name2 = save_filename_prefix2 + '_cat2.txt'
             saveplot_name2 = save_filename_prefix2 + '_cat2.pdf'
@@ -1577,100 +1470,77 @@ def main():
             gifname = motion_outfile_prefix + "_" + dt_match + "_anime.gif"
             motion_outfile_prefix = motion_outfile_prefix + "_" + dt_match + "motion"
         else:
-            savefits_name2 = os.path.join(args.datadir,args.savefits_name2)
-            savecatalog_name2 = os.path.join(args.datadir,args.savecatalog_name2)
-            saveplot_name2 = os.path.join(args.datadir,args.saveplot_name2)
-            diffcatalog_name2 = os.path.join(args.datadir,args.diffcatalog_name2)
-            diffplot_name2 = os.path.join(args.datadir,args.diffplot_name2)
+            savefits_name2 = os.path.join(args.datadir, args.savefits_name2)
+            savecatalog_name2 = os.path.join(args.datadir, args.savecatalog_name2)
+            saveplot_name2 = os.path.join(args.datadir, args.saveplot_name2)
+            diffcatalog_name2 = os.path.join(args.datadir, args.diffcatalog_name2)
+            diffplot_name2 = os.path.join(args.datadir, args.diffplot_name2)
             motion_outfile_prefix = args.motion_outfile_prefix
             gifname = os.path.join(args.datadir, args.gifname)
         if args.gifname is not None:
             gifname = os.path.join(args.datadir, args.gifname)
 
     sew_params = ["X_IMAGE", "Y_IMAGE", "FLUX_ISO", "FLUX_RADIUS", "FLAGS", "KRON_RADIUS", "A_IMAGE", "B_IMAGE",
-                              "THETA_IMAGE"]
+                  "THETA_IMAGE"]
 
     if (args.single or args.rawfile2 is None) and args.quick_ring_check is None:
-        sew_out_table1, im_med1 = process_raw(args.rawfile1, kernel_w=args.kernel_w,
-                                              DETECT_MINAREA=args.DETECT_MINAREA, THRESH=args.THRESH,
-                                              DEBLEND_MINCONT=args.DEBLEND_MINCONT,
-                                              sewpy_params=sew_params,
-                                              cropxs=cropxs, cropys=cropys,
-                                              clean=args.clean,
+        sew_out_table1, im_med1 = process_raw(args.rawfile1, kernel_w=args.kernel_w, DETECT_MINAREA=args.DETECT_MINAREA,
+                                              THRESH=args.THRESH, DEBLEND_MINCONT=args.DEBLEND_MINCONT,
+                                              sewpy_params=sew_params, cropxs=cropxs, cropys=cropys, clean=args.clean,
                                               savefits_name=savefits_name1, overwrite_fits=True,
                                               saveplot_name=saveplot_name1, savecatalog_name=savecatalog_name1,
-                                              search_xs=args.search_xs, search_ys=args.search_ys,  show=args.show
-                                              )
+                                              search_xs=args.search_xs, search_ys=args.search_ys, show=args.show)
         print("Processing single image. Done.")
         if args.ring:
             if args.clustering:
-                find_ring_pattern_clustering(sew_out_table1, pattern_center=args.pattern_center,
-                                             radius=args.ring_rad, rad_frac=args.ring_frac,
-                                             rad_tol_frac=args.ring_tol,
-                                             n_rings=2, rad_inner=0.5, rad_outer=1.2,)
+                find_ring_pattern_clustering(sew_out_table1, pattern_center=args.pattern_center, radius=args.ring_rad,
+                                             rad_frac=args.ring_frac, rad_tol_frac=args.ring_tol, n_rings=2,
+                                             rad_inner=0.5, rad_outer=1.2, )
             else:
-                clast, rlast, r2std_last, sew_slice, df_slice = find_ring_pattern(sew_out_table1, pattern_center=args.pattern_center,
-                                                                        radius=args.ring_rad, rad_frac=args.ring_frac,
-                                                                        n_iter=20, rad_tol_frac=args.ring_tol,
-                                                                        phase_offset_rad = args.phase_offset_rad,
-                                                                        fix_center=True, var_tol=4000)
-                plot_raw_cat(args.rawfile1, sew_slice, df=df_slice, center_pattern=clast,
-                             cropxs=cropxs, cropys=cropys,
-                             kernel_w=3,
-                             save_catlog_name=ring_cat_file,
-                             save_for_vvv=vvv_ring_file,
+                clast, rlast, r2std_last, sew_slice, df_slice = find_ring_pattern(sew_out_table1,
+                                                                                  pattern_center=args.pattern_center,
+                                                                                  radius=args.ring_rad,
+                                                                                  rad_frac=args.ring_frac, n_iter=20,
+                                                                                  rad_tol_frac=args.ring_tol,
+                                                                                  phase_offset_rad=args.phase_offset_rad,
+                                                                                  fix_center=True, var_tol=4000)
+                plot_raw_cat(args.rawfile1, sew_slice, df=df_slice, center_pattern=clast, cropxs=cropxs, cropys=cropys,
+                             kernel_w=3, save_catlog_name=ring_cat_file, save_for_vvv=vvv_ring_file,
                              saveplot_name=ring_file, show=False)
             if os.path.exists(vvv_ring_file):
                 print("Let's do a quick ring check on Panel IDs, using file {}".format(vvv_ring_file))
-                quick_check_raw_ring(args.rawfile1,
-                                 save_for_vvv=vvv_ring_file,
-                                 saveplot_name=vvv_ring_file[:-4] + ".png", show=args.show)
+                quick_check_raw_ring(args.rawfile1, save_for_vvv=vvv_ring_file,
+                                     saveplot_name=vvv_ring_file[:-4] + ".png", show=args.show)
 
         exit(0)
 
     elif args.quick_ring_check is not None:
         print("doing a quick check on Panel IDs, using file {}".format(args.quick_ring_check))
-        quick_check_raw_ring(args.rawfile1,
-                             save_for_vvv=args.quick_ring_check,
-                             saveplot_name=args.quick_ring_check[:-4]+".png", show=args.show)
+        quick_check_raw_ring(args.rawfile1, save_for_vvv=args.quick_ring_check,
+                             saveplot_name=args.quick_ring_check[:-4] + ".png", show=args.show)
 
     else:
-        sew_out_table1, im_med1 = process_raw(args.rawfile1, kernel_w=args.kernel_w,
-                                              DETECT_MINAREA=args.DETECT_MINAREA, THRESH=args.THRESH,
-                                              DEBLEND_MINCONT=args.DEBLEND_MINCONT,
-                                              sewpy_params=sew_params,
-                                              cropxs=cropxs, cropys=cropys,
-                                              clean=args.clean,
-                                              savefits_name=savefits_name1, overwrite_fits=True,
-                                              saveplot_name=None, savecatalog_name=savecatalog_name1,
-                                              search_xs=args.search_xs, search_ys=args.search_ys
-                                              )
-        sew_out_table2, im_med2 = process_raw(args.rawfile2, kernel_w=args.kernel_w,
-                                            DETECT_MINAREA=args.DETECT_MINAREA, THRESH=args.THRESH,
-                                            DEBLEND_MINCONT=args.DEBLEND_MINCONT,
-                                            sewpy_params=sew_params,
-                                            cropxs=cropxs, cropys=cropys,
-                                            clean=args.clean,
-                                            savefits_name=savefits_name2, overwrite_fits=True,
-                                            saveplot_name=None, savecatalog_name=savecatalog_name2,
-                                            search_xs=args.search_xs, search_ys=args.search_ys
-                                            )
+        sew_out_table1, im_med1 = process_raw(args.rawfile1, kernel_w=args.kernel_w, DETECT_MINAREA=args.DETECT_MINAREA,
+                                              THRESH=args.THRESH, DEBLEND_MINCONT=args.DEBLEND_MINCONT,
+                                              sewpy_params=sew_params, cropxs=cropxs, cropys=cropys, clean=args.clean,
+                                              savefits_name=savefits_name1, overwrite_fits=True, saveplot_name=None,
+                                              savecatalog_name=savecatalog_name1, search_xs=args.search_xs,
+                                              search_ys=args.search_ys)
+        sew_out_table2, im_med2 = process_raw(args.rawfile2, kernel_w=args.kernel_w, DETECT_MINAREA=args.DETECT_MINAREA,
+                                              THRESH=args.THRESH, DEBLEND_MINCONT=args.DEBLEND_MINCONT,
+                                              sewpy_params=sew_params, cropxs=cropxs, cropys=cropys, clean=args.clean,
+                                              savefits_name=savefits_name2, overwrite_fits=True, saveplot_name=None,
+                                              savecatalog_name=savecatalog_name2, search_xs=args.search_xs,
+                                              search_ys=args.search_ys)
 
-        naive_comparison(sew_out_table1, sew_out_table2, im_med1, im_med2,
-                         min_dist=args.min_dist,
-                         diffcat1=diffcatalog_name1, diffcat2=diffcatalog_name2,
-                         outfile1=saveplot_name1, outfile2=saveplot_name2,
-                         cropxs=cropxs, cropys=cropys,
-                         verbose=args.verbose,
-                         center=np.array(args.center)
-                         )
+        naive_comparison(sew_out_table1, sew_out_table2, im_med1, im_med2, min_dist=args.min_dist,
+                         diffcat1=diffcatalog_name1, diffcat2=diffcatalog_name2, outfile1=saveplot_name1,
+                         outfile2=saveplot_name2, cropxs=cropxs, cropys=cropys, verbose=args.verbose,
+                         center=np.array(args.center))
 
-        plot_diff_labelled(args.rawfile1, args.rawfile2, diffcatalog_name1, diffcatalog_name2,
-                           ind1=None, ind2=None,
-                           motion_outfile_prefix=motion_outfile_prefix,
-                           outfile1=diffplot_name1, outfile2=diffplot_name2,
-                           cropxs=cropxs, cropys=cropys,
-                           center=np.array(args.center))
+        plot_diff_labelled(args.rawfile1, args.rawfile2, diffcatalog_name1, diffcatalog_name2, ind1=None, ind2=None,
+                           motion_outfile_prefix=motion_outfile_prefix, outfile1=diffplot_name1,
+                           outfile2=diffplot_name2, cropxs=cropxs, cropys=cropys, center=np.array(args.center))
 
         grid2gif(diffplot_name1, diffplot_name2, gifname)
 

--- a/focal_plane.py
+++ b/focal_plane.py
@@ -768,11 +768,11 @@ def plot_raw_cat(rawfile, sewtable, df=None, center_pattern=np.array([1891.25, 1
         plt.show()
 
     from astropy.io import ascii
-    ascii.write(df.group_by('#'), save_catlog_name, overwrite=True)
+    ascii.write(sewtable.group_by('#'), save_catlog_name, overwrite=True)
 
     if df is not None:
         # no 'crappy' files for vvv (N.B 'crappy' is undefined and subject to change)
-        df_vvv = df.to_pandas()
+        df_vvv = sewtable.to_pandas()
         df_vvv['A_x_KR_in_pix'] = df_vvv["KRON_RADIUS"] * df_vvv['A_IMAGE'] / 2.
         df_vvv['B_x_KR_in_pix'] = df_vvv["KRON_RADIUS"] * df_vvv['B_IMAGE'] / 2.
         df_vvv = df_vvv[

--- a/focal_plane.py
+++ b/focal_plane.py
@@ -673,8 +673,8 @@ def process_raw(rawfile, kernel_w = 3,
     sew_out = sew(savefits_name)
     sew_out['table'].sort('FLUX_ISO')
     sew_out['table'].reverse()
-    sew_out['table']['FLUX_AREA'] = np.pi * sew_out['table']['KRON_RADIUS'] * sew_out['table']['KRON_RADIUS'] * \
-                                    sew_out['table']['A_IMAGE'] * sew_out['table']['A_IMAGE']
+    sew_out['table']['FLUX_AREA'] = (1. /4.) *np.pi * sew_out['table']['KRON_RADIUS'] * sew_out['table']['KRON_RADIUS'] * \
+                                    sew_out['table']['A_IMAGE'] * sew_out['table']['B_IMAGE']
     if clean:
         sew_out['table'] = sew_out['table'][sew_out['table']['FLAGS'] <= 16]
         #sew_out['table'] = sew_out['table'][(sew_out['table']['FLUX_ISO'] / sew_out['table']['FLUX_AREA']) > 0.3]
@@ -817,7 +817,10 @@ def plot_raw_cat(rawfile, sewtable, df=None, center_pattern=np.array([1891.25, 1
     if df is not None:
         # no crappy files for vvv
         df_vvv = sew_slice.to_pandas()
-        df_vvv = df_vvv[['Panel_ID_guess', '#', 'X_IMAGE', 'Y_IMAGE']]
+        df_vvv['A_x_KR_in_pix'] = df_vvv["KRON_RADIUS"]*df_vvv['A_IMAGE'] / 2.
+        df_vvv['B_x_KR_in_pix'] = df_vvv["KRON_RADIUS"]*df_vvv['B_IMAGE'] / 2.
+        df_vvv = df_vvv[['Panel_ID_guess', '#', 'X_IMAGE', 'Y_IMAGE', "A_x_KR_in_pix", "B_x_KR_in_pix",
+                                                      "THETA_IMAGE",'FLUX_AREA','KRON_RADIUS']]
         df_vvv.sort_values('#').to_csv(save_for_vvv, index=False)
         print("Mean center X {} Y {}".format(np.mean(df_vvv['X_IMAGE']), np.mean(df_vvv['Y_IMAGE'])))
 

--- a/focal_plane_height_search.py
+++ b/focal_plane_height_search.py
@@ -1,0 +1,161 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+P2s = [1221, 1222, 1223, 1224, 1225, 1226, 1227, 1228,
+       1321, 1322, 1323, 1324, 1325, 1326, 1327, 1328,
+       1421, 1422, 1423, 1424, 1425, 1426, 1427, 1428,
+       1121, 1122, 1123, 1124, 1125, 1126, 1127, 1128]
+
+P1s = [1211, 1212, 1213, 1214,
+       1311, 1312, 1313, 1314,
+       1411, 1412, 1413, 1414,
+       1111, 1112, 1113, 1114]
+
+S1s = [2111, 2112,
+       2211, 2212,
+       2311, 2312,
+       2411, 2412]
+
+S2s = [2121,2122,2123,2124,
+       2221,2222,2223,2224,
+       2321,2322,2323,2324,
+       2421,2422,2423,2424]
+
+sectorDict = {'P1':P1s, 'P2':P2s, 'S2':P1s}
+
+data_dir='./data/FP_search'
+#Timestamp matching the number of layers added on the central module to 'move' the focal plane. Each layer is 5mm.
+layers_to_times_dict={"2019_12_13_22_06_23":0,
+                      "2019_12_13_22_22_26":1,
+                      "2019_12_13_22_55_27":2,
+                      "2019_12_13_23_14_24":3,
+                      "2019_12_13_23_41_36":4}
+
+def get_sewpy_data(csv_file):
+    data=np.genfromtxt(csv_file, delimiter=',',skip_header=True)
+    return data
+
+def FindPanelPosition(panel, ring, focal_plane_ordering=False):
+    panel_id = str(panel)
+    if list(panel_id)[0] == "1":
+        is_primary = True
+    else:
+        is_primary = False
+    if list(panel_id)[2] == "1":
+        is_inner_ring = True
+    else:
+        is_inner_ring = False
+    quadrant = float(list(panel_id)[1])
+    segment = float(list(panel_id)[3])
+    total_segment = 0.
+    if is_primary and is_inner_ring:
+        total_segment = 4.
+    elif is_primary and not is_inner_ring:
+        total_segment = 8.
+    elif not is_primary and is_inner_ring:
+        total_segment = 2.
+    elif not is_primary and not is_inner_ring:
+        total_segment = 4.
+    if focal_plane_ordering:
+        phase = 2*np.pi - ((quadrant - 1) * 0.5 * np.pi + 0.5 * np.pi * (segment - 0.5) / total_segment) - (0.5)*np.pi
+    else:
+        phase = ((quadrant - 1) * 0.5 * np.pi + 0.5 * np.pi * (segment - 0.5) / total_segment) #original phase form
+    phase_width = 0.5 * np.pi * (1.0) / total_segment
+    if is_inner_ring:
+        radius = 1.5
+    else:
+        radius = 3.0
+    if ring == "S2":
+        radius *= 1.5
+    return radius, phase, phase_width
+
+def plot_param_fourier_transform(time, data_dir = data_dir):
+    fig_F, ax_FT = plt.subplots(figsize=(6, 5), ncols=1)
+    for ring in sectorDict.keys():
+        ring_filename = "res_focal_plane_" + time + "_ring_search_vvv_" + ring + ".csv"
+        ring_data = get_sewpy_data(data_dir + '/' + ring_filename)
+        N = len(ring_data)
+        radius = np.empty(N)
+        phase = np.empty(N)
+        phi = 2*np.pi/N
+        for i in range(N):
+            radius[i], phase[i], _ = FindPanelPosition(ring_data[i, 0], ring, False)
+            if ring_data[i,0] == 1111 or ring_data[i,0] == 1121:
+                index_1=i
+        eccentricity = np.sqrt(1. - ((ring_data[:, 5]) / (ring_data[:, 4])) ** 2)
+
+        a0 = np.sum(eccentricity) / N
+        aN = np.empty(N)
+        bN = np.empty(N)
+        for i in range(N):
+            aN[i] = (2 / N) * np.sum(eccentricity * np.cos((i+1) * phase))
+            bN[i] = (2 / N) * np.sum(eccentricity * np.sin((i+1) * phase))
+
+        f_transform = (a0 + aN + bN)
+        c = 'k'
+        if ring == 'P1':
+            c = 'r'
+        elif ring == 'P2':
+            c = 'g'
+        elif ring == 'S2':
+            c = 'b'
+        ax_FT.plot(np.rad2deg(phase), f_transform, 'o', label='ring {}'.format(ring), color=c)
+        print("For ring {}:\n\tC_0 = {}, C_1 = {}, S_1 = {} for phase i=1 ({},{})= {}".format(ring,a0, aN[index_1], bN[index_1],ring_data[index_1,0],index_1,np.rad2deg(phase[index_1])))
+    ax_FT.legend()
+    plt.show()
+
+def plot_eccentricity_on_pattern(layers_to_times_dict):
+    '''
+    Plots the eccentricity in color onto the mirror pattern.
+    '''
+    for time,layer in layers_to_times_dict.items():
+        fig, ax = plt.subplots(figsize=(6, 5), ncols=1)
+        for ring in sectorDict.keys():
+            ring_filename = "res_focal_plane_"+time+"_ring_search_vvv_"+ring+".csv"
+            ring_data = get_sewpy_data(data_dir + '/' + ring_filename)
+            N = len(ring_data)
+            radius = np.empty(N)
+            phase = np.empty(N)
+            for i in range(N):
+                radius[i], phase[i], _ = FindPanelPosition(ring_data[i,0], ring, False)
+            coor_x = radius * np.cos(phase)
+            coor_y = radius * np.sin(phase)
+
+            import matplotlib as mpl
+
+            # cmap=plt.cm.viridis
+            cmap = plt.cm.jet
+            cmaplist = [cmap(i) for i in range(cmap.N)]
+            # force the first color entry to be grey
+            cmaplist[0] = (.5, .5, .5, 1.0)
+
+            # create the new map
+            cmap = mpl.colors.LinearSegmentedColormap.from_list('Custom cmap', cmaplist, cmap.N)
+
+            # define the bins and normalize
+            bounds = np.linspace(0,1,21)
+            norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
+
+            eccentricity = np.sqrt(1. - ((ring_data[:, 5])/ (ring_data[:, 4])) ** 2)
+
+            scatter = plt.scatter(coor_x, coor_y, c=eccentricity,
+                                  cmap=cmap,norm=norm)
+            panel_string = [str(int(i)) for i in ring_data[:,0]]
+            for i in range(N):
+                plt.annotate(panel_string[i], (coor_x[i], coor_y[i]))
+        plt.title("Layer " + str(layer))
+        plt.axis('off')
+        plt.tight_layout()
+        ax.set_yticklabels([])
+        ax.set_xticklabels([])
+        cb = fig.colorbar(scatter, ax=ax)
+        cb.set_label('Eccentricity', rotation=270)
+        plt.savefig(data_dir+"/eccentricity_layer_" + str(layer)+".png")
+    plt.show()
+
+if __name__ == '__main__':
+    time='2019_12_15_00_48_33'
+    res_dir='./data/'
+    plot_param_fourier_transform(time,data_dir=res_dir)
+    plot_eccentricity_on_pattern(layers_to_times_dict)

--- a/focal_plane_height_search.py
+++ b/focal_plane_height_search.py
@@ -19,14 +19,35 @@ sectorDict = {'P1': P1s, 'P2': P2s, 'S2': P1s}
 layers_to_times_dict_5mm_motion = {"2019_12_13_22_06_23": 0, "2019_12_13_22_22_26": 1, "2019_12_13_22_55_27": 2,
                                    "2019_12_13_23_14_24": 3, "2019_12_13_23_41_36": 4}
 
-layers_to_times_prefix_dict_1mm_motion = {"2019_12_16_02_34_54": {"_M2_z_0": 0}, "2019_12_16_02_37_06": {"_M2_z_1": -1},
+layers_to_times_prefix_dict_1mm_motion = {"2019_12_16_02_34_54": {"_M2_z_0": 0},
+                                          "2019_12_16_02_37_06": {"_M2_z_1": -1},
                                           "2019_12_16_02_41_37": {"_M2_z_2": -2},
                                           "2019_12_16_02_44_38": {"_M2_z_3": -3},
-                                          "2019_12_16_02_49_05": {"_M2_z_4": -4}, "2019_12_16_02_55_13": {"_M2_z_0": 0},
+                                          "2019_12_16_02_49_05": {"_M2_z_4": -4},
+                                          "2019_12_16_02_55_13": {"_M2_z_0": 0},
                                           "2019_12_16_03_04_24": {"_M2_z_p1": 1},
                                           "2019_12_16_03_06_46": {"_M2_z_p2": 2},
                                           "2019_12_16_03_09_05": {"_M2_z_p3": 3},
                                           "2019_12_16_03_11_44": {"_M2_z_p4": 4}, }
+
+layers_to_times_prefix_dict_025mm_motion = {"2019_12_17_00_32_31":{"_z-1-1"   :0  },
+                                            "2019_12_17_00_35_18":{"_z-1+0.25":.25  },
+                                            "2019_12_17_00_37_33":{"_z-1+0.5" :.5  },
+                                            "2019_12_17_00_39_57":{"_z-1+0.75" :.75 },
+                                            "2019_12_17_00_42_43":{"_z-1+1.0"  :1 },
+                                            "2019_12_17_00_45_16":{"_z-1+1.25" :1.25 },
+                                            "2019_12_17_00_47_37":{"_z-1+1.5"  :1.5 },
+                                            "2019_12_17_00_49_44":{"_z-1+1.75":1.75  },
+                                            "2019_12_17_00_52_12":{"_z-1+2.0" :2.  },
+                                            "2019_12_17_00_58_22":{"_z-1+2.5" :2.5  },
+                                            "2019_12_17_01_16_22":{"_z-1"      :0 },
+                                            "2019_12_17_01_17_29":{"_z-1-0.25":-.25  },
+                                            "2019_12_17_01_19_43":{"_z-1-0.5" :-.5  },
+                                            "2019_12_17_01_22_15":{"_z-1-0.75" : -0.75},
+                                            "2019_12_17_01_24_26":{"_z-1-1.0" : -1. },
+                                            "2019_12_17_01_26_38":{"_z-1-1.25" :-1.25 },
+                                            "2019_12_17_01_28_57":{"_z-1-1.5"  :-1.5},
+                                            "2019_12_17_01_31_47":{"_z-1-1.75":-1.75}}
 
 
 def get_sewpy_data(csv_file):
@@ -210,8 +231,12 @@ def plot_avg_area_by_z_layer(layer_dict, res_dir):
     for ring in sectorDict.keys():
         if ring == "P2":
             continue
-        flux_area_avg = np.empty([9])
-        layer_value_array = np.empty([9])
+        if ring == "P1":
+            flux_area_avg = np.empty([15])
+            layer_value_array = np.empty([15])
+        elif ring == "S2":
+            flux_area_avg = np.empty([14])
+            layer_value_array = np.empty([14])
         i = 0
         for time, layer_prefix_dict in layer_dict.items():
             if time == "2019_12_16_02_55_13":
@@ -223,26 +248,29 @@ def plot_avg_area_by_z_layer(layer_dict, res_dir):
                     ring_data = get_sewpy_data(ring_filepath)
                     ring_data, flux_area, first_harmonic_index = flux_area_fourier_transform(ring_data, ring)
                     flux_area_avg[i] = flux_area['C_0'][0]
+                    # print(flux_area_avg[i])
                     layer_value_array[i] = layer
                     i += 1
                 else:
                     continue
         plt.figure()
         plt.plot(layer_value_array, flux_area_avg, 'o', linestyle=' ', label=ring)
+        print(layer_value_array)
+        print(flux_area_avg)
         plt.title("Flux Area Averages")
         plt.xlabel("M2 Motion (mm)")
-        plt.savefig("{}/{}_avg_area ".format(res_dir, ring))
         plt.legend()
         plt.ylabel("Flux Area (pix^2)")
+        plt.savefig("{}/{}_avg_area ".format(res_dir, ring))
         plt.show()
 
 
 def main():
-    res_dir = './data/Focal_Plane_Search_M2_Z_motion_1mm'
-    plot_fourier_decomp_by_z_layer(layers_to_times_prefix_dict_1mm_motion, res_dir, "eccentricity")
-    plot_avg_area_by_z_layer(layers_to_times_prefix_dict_1mm_motion, res_dir)
-    plot_eccentricity_on_pattern(layers_to_times_dict_5mm_motion,
-                                 data_dir='./data/Focal_Plane_Search_camera_Z_motion_5mm')
+    res_dir = '/Users/deividribeiro/Desktop/Focal_Plane_Search_camera_Z_motion_0.25mm/'
+    # plot_fourier_decomp_by_z_layer(layers_to_times_prefix_dict_1mm_motion, res_dir, "eccentricity")
+    # plot_eccentricity_on_pattern(layers_to_times_dict_5mm_motion,
+    #                              data_dir='./data/Focal_Plane_Search_camera_Z_motion_5mm')
+    plot_avg_area_by_z_layer(layers_to_times_prefix_dict_025mm_motion, res_dir)
 
 
 if __name__ == '__main__':

--- a/movie_maker.py
+++ b/movie_maker.py
@@ -1,0 +1,97 @@
+import argparse
+import os
+import subprocess
+
+from focal_plane import read_raw, get_datetime_rawname
+import matplotlib.pyplot as plt
+
+try:
+    import cv2
+    has_cv2 = True
+except:
+    print("Can't import cv2!!")
+    has_cv2 = False
+
+def images2gif(im_list, output_gif):
+    str_im_list = ' '.join(im_list)
+    str1 = 'convert -delay 50 -loop 0 -quality 50 -density 144 ' + str_im_list +' '+output_gif
+    print(str1)
+    subprocess.call(str1, shell=True)
+
+def main():
+    parser = argparse.ArgumentParser(description="Makes a movie out of the .RAW files passed as arguments."
+                                                 "Use a list of RAW files with the space escaped by \'\\\' in the name."
+                                                 "You can read a text file of these names with `awk -F\" '{printf(\"\%s "
+                                                 "\",$1)}' test.txt`, then copy/paste that chunk of text into this call.")
+
+    parser.add_argument("RAW_files", type=str, default=None, nargs="*")
+    parser.add_argument('--output', type=str, default='movie_maker_animation.gif', help="Name of output file to make animation.")
+
+    parser.add_argument('--kernel_w', type=int, default=3,
+                        help="If you have cv2, this is the median blurring kernel width"
+                             "our default is 3 (for a 3x3 kernel).")
+    parser.add_argument('--datadir', default="data",
+                        help="Folder to save all output files. Default is ./data (ignored by git)")
+    parser.add_argument('--gifname', default=None,  # default="compare.gif",
+                        help="File name to save gif animation. ")
+
+    parser.add_argument('--cropx1', default=1050,  # default=1170,
+                        # default=(1350, 1800),
+                        type=int,
+                        help="zooming into xlim that you want to plot, use None for no zoom, default is (1650, 2100).")
+    parser.add_argument('--cropx2', default=2592,  # default=1970,
+                        # default=(1350, 1800),
+                        type=int,
+                        help="zooming into xlim that you want to plot, use None for no zoom, default is (1650, 2100).")
+
+    parser.add_argument('--cropy1',  # default=1410,
+                        default=1850, type=int,
+                        help="zooming into ylim that you want to plot, use None for no zoom, default is (1250, 800).")
+    parser.add_argument('--cropy2',  # default=610,
+                        default=250,
+                        type=int,
+                        help="zooming into ylim that you want to plot, use None for no zoom, default is (1250, 800).")
+    parser.add_argument('--nozoom', action='store_true', help="Do not zoom/crop the image. ")
+
+    args = parser.parse_args()
+
+    if args.nozoom:
+        cropxs = None
+        cropys = None
+    else:
+        cropxs = (args.cropx1, args.cropx2)
+        cropys = (args.cropy1, args.cropy2)
+
+    png_list = []
+    for single_file in args.RAW_files:
+        im_raw = read_raw(single_file)
+        im_raw = im_raw[cropys[1]:cropys[0], cropxs[0]:cropxs[1]]
+        print("Read file {}".format(single_file))
+        if has_cv2:
+            median = cv2.medianBlur(im_raw, args.kernel_w)
+        else:
+            print("+++ System doesn't have opencv installed, using noisy raw image without median blurring +++")
+            median = im_raw
+
+        dt_match = get_datetime_rawname(single_file)
+        single_outfile = os.path.join(args.datadir, "res_focal_plane_" + dt_match + ".png")
+        print(single_outfile)
+
+        if has_cv2:
+            cv2.imwrite(single_outfile, median)
+        else:
+            if cropxs is not None:
+                plt.xlim(cropxs)
+            if cropys is not None:
+                plt.ylim(cropys)
+            plt.imshow(median, cmap='gray')
+            plt.savefig(single_outfile)
+
+        png_list.append(single_outfile)
+
+    print("Output: " + args.datadir + args.output)
+    output_gif = os.path.join(args.datadir, args.output)
+    images2gif(png_list, output_gif)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
ba85fa7 Changes some variable names because they were confusing (names were too short or similar to other variables in the same scope). 
Added some method comments describing what happened inside those complicated methods. 

dc8744d  Pycharm reformat just used the standard reformat, so the width is uniform and spacing is consistent. Nothing really functional is affected here.

c0993cf New file to calculate harmonics and averages over multiple vvv.csv files for comparison in order to plot and find the focal plane as a function of moving the camera/M1/M2.

8ccd950 Adds a script to make  .gif  on multiple RAW files. The input arguments after the `--output filename` and other image options is the list of filenames separated by spaces. Filenames have to have `\ ` escaping the space in the name of the RAW file. 

